### PR TITLE
feat: llama-index code migration!

### DIFF
--- a/dags/hivemind_etl_helpers/discord_mongo_summary_etl.py
+++ b/dags/hivemind_etl_helpers/discord_mongo_summary_etl.py
@@ -10,7 +10,9 @@ from hivemind_etl_helpers.src.db.discord.find_guild_id import (
 )
 from hivemind_etl_helpers.src.document_node_parser import configure_node_parser
 from hivemind_etl_helpers.src.utils.sort_summary_docs import sort_summaries_daily
-from llama_index.response_synthesizers import get_response_synthesizer
+from llama_index.core.response_synthesizers import get_response_synthesizer
+from llama_index.llms.openai import OpenAI
+from llama_index.core import Settings
 from tc_hivemind_backend.db.pg_db_utils import setup_db
 from tc_hivemind_backend.db.utils.model_hyperparams import load_model_hyperparams
 from tc_hivemind_backend.embeddings.cohere import CohereEmbedding
@@ -93,16 +95,16 @@ def process_discord_summaries(community_id: str, verbose: bool = False) -> None:
     node_parser = configure_node_parser(chunk_size=chunk_size)
     pg_vector = PGVectorAccess(table_name=table_name, dbname=dbname)
 
-    embed_model = CohereEmbedding()
+    Settings.node_parser = node_parser
+    Settings.embed_model = CohereEmbedding()
+    Settings.chunk_size = chunk_size
+    Settings.llm = OpenAI(model="gpt-3.5-turbo")
 
     pg_vector.save_documents_in_batches(
         community_id=community_id,
         documents=docs_daily_sorted,
         batch_size=100,
-        node_parser=node_parser,
         max_request_per_minute=None,
-        embed_model=embed_model,
-        embed_dim=embedding_dim,
         request_per_minute=10000,
         deletion_query=deletion_query,
     )

--- a/dags/hivemind_etl_helpers/discord_mongo_vector_store_etl.py
+++ b/dags/hivemind_etl_helpers/discord_mongo_vector_store_etl.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from datetime import timedelta
 
@@ -13,6 +12,8 @@ from tc_hivemind_backend.db.pg_db_utils import setup_db
 from tc_hivemind_backend.db.utils.model_hyperparams import load_model_hyperparams
 from tc_hivemind_backend.embeddings.cohere import CohereEmbedding
 from tc_hivemind_backend.pg_vector_access import PGVectorAccess
+from llama_index.core import Settings
+from llama_index.llms.openai import OpenAI
 
 
 def process_discord_guild_mongo(community_id: str) -> None:
@@ -52,7 +53,10 @@ def process_discord_guild_mongo(community_id: str) -> None:
     node_parser = configure_node_parser(chunk_size=chunk_size)
     pg_vector = PGVectorAccess(table_name=table_name, dbname=dbname)
 
-    embed_model = CohereEmbedding()
+    Settings.node_parser = node_parser
+    Settings.embed_model = CohereEmbedding()
+    Settings.chunk_size = chunk_size
+    Settings.llm = OpenAI(model="gpt-3.5-turbo")
 
     pg_vector.save_documents_in_batches(
         community_id=community_id,
@@ -60,19 +64,5 @@ def process_discord_guild_mongo(community_id: str) -> None:
         batch_size=100,
         node_parser=node_parser,
         max_request_per_minute=None,
-        embed_model=embed_model,
-        embed_dim=embedding_dim,
         request_per_minute=10000,
-        # max_request_per_day=REQUEST_PER_DAY,
     )
-
-
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "community_id", type=str, help="the Community that the guild is related to"
-    )
-    args = parser.parse_args()
-
-    process_discord_guild_mongo(community_id=args.community_id)

--- a/dags/hivemind_etl_helpers/github_etl.py
+++ b/dags/hivemind_etl_helpers/github_etl.py
@@ -21,7 +21,7 @@ from hivemind_etl_helpers.src.db.github.transform import (
     transform_issues,
     transform_prs,
 )
-from llama_index import Document
+from llama_index.core import Document
 from tc_hivemind_backend.db.pg_db_utils import setup_db
 
 

--- a/dags/hivemind_etl_helpers/src/db/discord/discord_raw_message_to_document.py
+++ b/dags/hivemind_etl_helpers/src/db/discord/discord_raw_message_to_document.py
@@ -4,7 +4,7 @@ from hivemind_etl_helpers.src.db.discord.fetch_raw_messages import fetch_raw_mes
 from hivemind_etl_helpers.src.db.discord.utils.transform_discord_raw_messges import (
     transform_discord_raw_messages,
 )
-from llama_index import Document
+from llama_index.core import Document
 
 
 def discord_raw_to_docuemnts(

--- a/dags/hivemind_etl_helpers/src/db/discord/summary/prepare_summaries.py
+++ b/dags/hivemind_etl_helpers/src/db/discord/summary/prepare_summaries.py
@@ -8,20 +8,23 @@ from hivemind_etl_helpers.src.db.discord.utils.transform_discord_raw_messges imp
     transform_discord_raw_messages,
 )
 from hivemind_etl_helpers.src.utils.summary_base import SummaryBase
-from llama_index import Document, ServiceContext
-from llama_index.llms import LLM
-from llama_index.response_synthesizers.base import BaseSynthesizer
+from llama_index.core import Document, Settings
+from llama_index.core.llms import LLM
+from llama_index.core.response_synthesizers.base import BaseSynthesizer
 
 
 class PrepareSummaries(SummaryBase):
     def __init__(
         self,
-        service_context: ServiceContext | None = None,
         response_synthesizer: BaseSynthesizer | None = None,
-        llm: LLM | None = None,
         verbose: bool = False,
+        **kwargs,
     ) -> None:
-        super().__init__(service_context, response_synthesizer, llm, verbose)
+        llm = kwargs.get("llm", Settings.llm)
+
+        super().__init__(
+            llm=llm, response_synthesizer=response_synthesizer, verbose=verbose
+        )
         # initialization
         self.prefix: str = ""
 

--- a/dags/hivemind_etl_helpers/src/db/discord/summary/summary_utils.py
+++ b/dags/hivemind_etl_helpers/src/db/discord/summary/summary_utils.py
@@ -1,4 +1,4 @@
-from llama_index import Document
+from llama_index.core import Document
 
 
 def transform_thread_summary_to_document(

--- a/dags/hivemind_etl_helpers/src/db/discord/utils/transform_discord_raw_messges.py
+++ b/dags/hivemind_etl_helpers/src/db/discord/utils/transform_discord_raw_messges.py
@@ -20,7 +20,7 @@ from hivemind_etl_helpers.src.db.discord.utils.prepare_reactions_id import (
     prepare_raction_ids,
 )
 from hivemind_etl_helpers.src.db.globals import DATE_FORMAT
-from llama_index import Document
+from llama_index.core import Document
 
 
 def transform_discord_raw_messages(

--- a/dags/hivemind_etl_helpers/src/db/discourse/raw_post_to_documents.py
+++ b/dags/hivemind_etl_helpers/src/db/discourse/raw_post_to_documents.py
@@ -4,7 +4,7 @@ from hivemind_etl_helpers.src.db.discourse.fetch_raw_posts import fetch_raw_post
 from hivemind_etl_helpers.src.db.discourse.utils.transform_raw_to_documents import (
     transform_raw_to_documents,
 )
-from llama_index import Document
+from llama_index.core import Document
 
 
 def fetch_discourse_documents(

--- a/dags/hivemind_etl_helpers/src/db/discourse/summary/prepare_summary.py
+++ b/dags/hivemind_etl_helpers/src/db/discourse/summary/prepare_summary.py
@@ -8,9 +8,8 @@ from hivemind_etl_helpers.src.db.discourse.summary.summary_utils import (
     transform_summary_to_document,
 )
 from hivemind_etl_helpers.src.utils.summary_base import SummaryBase
-from llama_index import Document, ServiceContext
-from llama_index.llms import LLM
-from llama_index.response_synthesizers.base import BaseSynthesizer
+from llama_index.core import Document, Settings
+from llama_index.core.response_synthesizers.base import BaseSynthesizer
 
 
 class DiscourseSummary(SummaryBase):
@@ -18,12 +17,15 @@ class DiscourseSummary(SummaryBase):
         self,
         forum_id: str,
         forum_endpoint: str,
-        service_context: ServiceContext | None = None,
         response_synthesizer: BaseSynthesizer | None = None,
-        llm: LLM | None = None,
         verbose: bool = False,
+        **kwargs,
     ) -> None:
-        super().__init__(service_context, response_synthesizer, llm, verbose)
+        llm = kwargs.get("llm", Settings.llm)
+
+        super().__init__(
+            llm=llm, response_synthesizer=response_synthesizer, verbose=verbose
+        )
         self.prefix = f"FORUM_ID: {forum_id} "
         self.forum_endpoint = forum_endpoint
 

--- a/dags/hivemind_etl_helpers/src/db/discourse/summary/summary_utils.py
+++ b/dags/hivemind_etl_helpers/src/db/discourse/summary/summary_utils.py
@@ -1,4 +1,4 @@
-from llama_index import Document
+from llama_index.core import Document
 
 
 def transform_summary_to_document(

--- a/dags/hivemind_etl_helpers/src/db/discourse/utils/transform_raw_to_documents.py
+++ b/dags/hivemind_etl_helpers/src/db/discourse/utils/transform_raw_to_documents.py
@@ -1,4 +1,4 @@
-from llama_index import Document
+from llama_index.core import Document
 from neo4j import Record
 
 

--- a/dags/hivemind_etl_helpers/src/db/gdrive/retrieve_documents.py
+++ b/dags/hivemind_etl_helpers/src/db/gdrive/retrieve_documents.py
@@ -1,4 +1,4 @@
-from llama_index import Document, download_loader
+from llama_index.core import Document, download_loader
 
 
 def retrieve_folder_documents(folder_id: str) -> list[Document]:

--- a/dags/hivemind_etl_helpers/src/db/github/load/prepare_deletion.py
+++ b/dags/hivemind_etl_helpers/src/db/github/load/prepare_deletion.py
@@ -1,5 +1,5 @@
 from hivemind_etl_helpers.src.utils.check_documents import check_documents
-from llama_index import Document
+from llama_index.core import Document
 
 
 class PrepareDeletion:

--- a/dags/hivemind_etl_helpers/src/db/github/transform/comments.py
+++ b/dags/hivemind_etl_helpers/src/db/github/transform/comments.py
@@ -1,5 +1,5 @@
 from hivemind_etl_helpers.src.db.github.schema import GitHubComment
-from llama_index import Document
+from llama_index.core import Document
 
 
 def transform_comments(data: list[GitHubComment]) -> list[Document]:

--- a/dags/hivemind_etl_helpers/src/db/github/transform/commits.py
+++ b/dags/hivemind_etl_helpers/src/db/github/transform/commits.py
@@ -1,5 +1,5 @@
 from hivemind_etl_helpers.src.db.github.schema import GitHubCommit
-from llama_index import Document
+from llama_index.core import Document
 
 
 def transform_commits(data: list[GitHubCommit]) -> list[Document]:

--- a/dags/hivemind_etl_helpers/src/db/github/transform/issues.py
+++ b/dags/hivemind_etl_helpers/src/db/github/transform/issues.py
@@ -1,5 +1,5 @@
 from hivemind_etl_helpers.src.db.github.schema import GitHubIssue
-from llama_index import Document
+from llama_index.core import Document
 
 
 def transform_issues(data: list[GitHubIssue]) -> tuple[list[Document], list[Document]]:

--- a/dags/hivemind_etl_helpers/src/db/github/transform/pull_requests.py
+++ b/dags/hivemind_etl_helpers/src/db/github/transform/pull_requests.py
@@ -1,5 +1,5 @@
 from hivemind_etl_helpers.src.db.github.schema import GitHubPullRequest
-from llama_index import Document
+from llama_index.core import Document
 
 
 def transform_prs(data: list[GitHubPullRequest]) -> list[Document]:

--- a/dags/hivemind_etl_helpers/src/document_node_parser.py
+++ b/dags/hivemind_etl_helpers/src/document_node_parser.py
@@ -1,9 +1,12 @@
 from typing import Callable
 
-from llama_index.node_parser import SimpleNodeParser
-from llama_index.node_parser.text.sentence import CHUNKING_REGEX, DEFAULT_PARAGRAPH_SEP
-from llama_index.text_splitter import SentenceSplitter
-from llama_index.utils import get_tokenizer
+from llama_index.core.node_parser import SimpleNodeParser
+from llama_index.core.node_parser.text.sentence import (
+    CHUNKING_REGEX,
+    DEFAULT_PARAGRAPH_SEP,
+)
+from llama_index.core.text_splitter import SentenceSplitter
+from llama_index.core.utils import get_tokenizer
 
 
 def configure_node_parser(

--- a/dags/hivemind_etl_helpers/src/utils/check_documents.py
+++ b/dags/hivemind_etl_helpers/src/utils/check_documents.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 from dateutil import parser
 from hivemind_etl_helpers.src.db.gdrive.db_utils import fetch_files_date_field
-from llama_index import Document
+from llama_index.core import Document
 
 
 def check_documents(

--- a/dags/hivemind_etl_helpers/src/utils/sort_summary_docs.py
+++ b/dags/hivemind_etl_helpers/src/utils/sort_summary_docs.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from llama_index import Document
+from llama_index.core import Document
 
 
 def sort_summaries_daily(

--- a/dags/hivemind_etl_helpers/tests/integration/test_discord_prepare_summary.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_discord_prepare_summary.py
@@ -4,18 +4,15 @@ from unittest import TestCase
 from bson import ObjectId
 from hivemind_etl_helpers.src.db.discord.discord_summary import DiscordSummary
 from hivemind_etl_helpers.src.utils.mongo import MongoSingleton
-from llama_index import Document, MockEmbedding, ServiceContext
-from llama_index.llms import MockLLM
+from llama_index.core import Document, MockEmbedding, Settings
+from llama_index.core.llms import MockLLM
 
 
 class TestDiscordGroupedDataPreparation(TestCase):
     def setUp(self):
-        self.mock_llm = MockLLM()
-        self.service_context = ServiceContext.from_defaults(
-            llm=MockLLM(),
-            chunk_size=512,
-            embed_model=MockEmbedding(embed_dim=1024),
-        )
+        Settings.llm = MockLLM()
+        Settings.chunk_size = 512
+        Settings.embed_model = MockEmbedding(embed_dim=1024)
 
     def setup_db(
         self,
@@ -101,9 +98,7 @@ class TestDiscordGroupedDataPreparation(TestCase):
         client[guild_id].drop_collection("rawinfos")
         self.setUp()
 
-        discord_summary = DiscordSummary(
-            service_context=self.service_context, llm=self.mock_llm
-        )
+        discord_summary = DiscordSummary()
         (
             thread_summary_docs,
             channel_summary_docs,
@@ -127,9 +122,7 @@ class TestDiscordGroupedDataPreparation(TestCase):
         from_date = datetime(2023, 8, 1)
         self.setUp()
 
-        discord_summary = DiscordSummary(
-            service_context=self.service_context, llm=self.mock_llm
-        )
+        discord_summary = DiscordSummary()
         (
             thread_summary_docs,
             channel_summary_docs,
@@ -221,9 +214,7 @@ class TestDiscordGroupedDataPreparation(TestCase):
         client[guild_id]["rawinfos"].insert_many(raw_data)
         self.setUp()
 
-        discord_summary = DiscordSummary(
-            service_context=self.service_context, llm=self.mock_llm
-        )
+        discord_summary = DiscordSummary()
         (
             thread_summary_docs,
             channel_summary_docs,
@@ -329,9 +320,7 @@ class TestDiscordGroupedDataPreparation(TestCase):
         client[guild_id]["rawinfos"].insert_many(raw_data)
         self.setUp()
 
-        discord_summary = DiscordSummary(
-            service_context=self.service_context, llm=self.mock_llm
-        )
+        discord_summary = DiscordSummary()
         (
             thread_summary_docs,
             channel_summary_docs,

--- a/dags/hivemind_etl_helpers/tests/integration/test_discord_prepare_thread_summaries.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_discord_prepare_thread_summaries.py
@@ -5,24 +5,22 @@ from hivemind_etl_helpers.src.db.discord.summary.prepare_summaries import (
     PrepareSummaries,
 )
 from hivemind_etl_helpers.src.utils.mongo import MongoSingleton
-from llama_index import MockEmbedding, ServiceContext
-from llama_index.llms import MockLLM
+from llama_index.core import MockEmbedding, Settings
+from llama_index.core.llms import MockLLM
 
 
 class TestPrepareSummaries(unittest.TestCase):
     def setUp(self):
         self.mock_llm = MockLLM()
-        self.service_context = ServiceContext.from_defaults(
-            llm=MockLLM(), chunk_size=256, embed_model=MockEmbedding(embed_dim=1024)
-        )
+        Settings.llm = MockLLM()
+        Settings.chunk_size = 256
+        Settings.embed_model = MockEmbedding(embed_dim=1024)
 
     def test_prepare_thread_summaries_empty_data(self):
         self.setUp()
         guild_id = "1234"
 
-        prepare_summaries = PrepareSummaries(
-            service_context=self.service_context, llm=self.mock_llm
-        )
+        prepare_summaries = PrepareSummaries()
         summaries = prepare_summaries.prepare_thread_summaries(
             guild_id=guild_id,
             raw_data_grouped={},
@@ -111,9 +109,7 @@ class TestPrepareSummaries(unittest.TestCase):
             }
         }
 
-        prepare_summaries = PrepareSummaries(
-            service_context=self.service_context, llm=self.mock_llm
-        )
+        prepare_summaries = PrepareSummaries()
         summaries = prepare_summaries.prepare_thread_summaries(
             guild_id=guild_id,
             raw_data_grouped=sample_grouped_data,

--- a/dags/hivemind_etl_helpers/tests/integration/test_discord_summary_prepare_channel_summaries.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_discord_summary_prepare_channel_summaries.py
@@ -3,23 +3,20 @@ import unittest
 from hivemind_etl_helpers.src.db.discord.summary.prepare_summaries import (
     PrepareSummaries,
 )
-from llama_index import Document, MockEmbedding, ServiceContext
-from llama_index.llms import MockLLM
+from llama_index.core import Document, MockEmbedding, Settings
+from llama_index.core.llms import MockLLM
 
 
 class TestPrepareSummaries(unittest.TestCase):
     def setUp(self):
-        self.mock_llm = MockLLM()
-        self.service_context = ServiceContext.from_defaults(
-            llm=MockLLM(), chunk_size=256, embed_model=MockEmbedding(embed_dim=1024)
-        )
+        Settings.llm = MockLLM()
+        Settings.chunk_size = 256
+        Settings.embed_model = MockEmbedding(embed_dim=1024)
 
     def test_prepare_channel_summaries_empty_data(self):
         self.setUp()
 
-        prepare_summaries = PrepareSummaries(
-            service_context=self.service_context, llm=self.mock_llm
-        )
+        prepare_summaries = PrepareSummaries()
         summaries, thread_docs = prepare_summaries.prepare_channel_summaries(
             thread_summaries={},
             summarization_query="Please give a summary of the data you have.",
@@ -44,9 +41,7 @@ class TestPrepareSummaries(unittest.TestCase):
             }
         }
 
-        prepare_summaries = PrepareSummaries(
-            service_context=self.service_context, llm=self.mock_llm
-        )
+        prepare_summaries = PrepareSummaries()
         summaries, thread_docs = prepare_summaries.prepare_channel_summaries(
             thread_summaries=sample_thread_summary,
             summarization_query="Please give a summary of the data you have.",

--- a/dags/hivemind_etl_helpers/tests/integration/test_discord_summary_prepare_daily_summaries.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_discord_summary_prepare_daily_summaries.py
@@ -3,23 +3,20 @@ import unittest
 from hivemind_etl_helpers.src.db.discord.summary.prepare_summaries import (
     PrepareSummaries,
 )
-from llama_index import Document, MockEmbedding, ServiceContext
-from llama_index.llms import MockLLM
+from llama_index.core import Document, MockEmbedding, Settings
+from llama_index.core.llms import MockLLM
 
 
 class TestPrepareSummaries(unittest.TestCase):
     def setUp(self):
-        self.mock_llm = MockLLM()
-        self.service_context = ServiceContext.from_defaults(
-            llm=MockLLM(), chunk_size=256, embed_model=MockEmbedding(embed_dim=1024)
-        )
+        Settings.llm = MockLLM()
+        Settings.chunk_size = 256
+        Settings.embed_model = MockEmbedding(embed_dim=1024)
 
     def test_prepare_daily_summaries_empty_data(self):
         self.setUp()
 
-        prepare_summaries = PrepareSummaries(
-            service_context=self.service_context, llm=self.mock_llm
-        )
+        prepare_summaries = PrepareSummaries()
         summaries, channel_docs = prepare_summaries.prepare_daily_summaries(
             channel_summaries={},
             summarization_query="Please give a summary of the data you have.",
@@ -39,9 +36,7 @@ class TestPrepareSummaries(unittest.TestCase):
             }
         }
 
-        prepare_summaries = PrepareSummaries(
-            service_context=self.service_context, llm=self.mock_llm
-        )
+        prepare_summaries = PrepareSummaries()
         summaries, channel_docs = prepare_summaries.prepare_daily_summaries(
             channel_summaries=sample_channel_summary,
             summarization_query="Please give a summary of the data you have.",

--- a/dags/hivemind_etl_helpers/tests/integration/test_discord_summary_transform_daily_summaries.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_discord_summary_transform_daily_summaries.py
@@ -3,7 +3,7 @@ import unittest
 from hivemind_etl_helpers.src.db.discord.summary.summary_utils import (
     transform_daily_summary_to_document,
 )
-from llama_index import Document
+from llama_index.core import Document
 
 
 class TestTransformDailySummaryToDocument(unittest.TestCase):

--- a/dags/hivemind_etl_helpers/tests/integration/test_discord_summary_utils.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_discord_summary_utils.py
@@ -4,7 +4,7 @@ from hivemind_etl_helpers.src.db.discord.summary.summary_utils import (
     transform_channel_summary_to_document,
     transform_thread_summary_to_document,
 )
-from llama_index import Document
+from llama_index.core import Document
 
 
 class TestTransformSummaryToDocument(unittest.TestCase):

--- a/dags/hivemind_etl_helpers/tests/integration/test_gdrive_convert_doc_to_id_date.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_gdrive_convert_doc_to_id_date.py
@@ -1,10 +1,12 @@
 from datetime import datetime, timezone
 from unittest import TestCase
+import pytest
 
 from hivemind_etl_helpers.src.utils.check_documents import process_doc_to_id_date
-from llama_index import Document
+from llama_index.core import Document
 
 
+@pytest.mark.skip(reason="GDrive ETL is not finished!")
 class TestDocumentGdriveProcessing(TestCase):
     def test_empty_documents(self):
         result = process_doc_to_id_date(

--- a/dags/hivemind_etl_helpers/tests/integration/test_gdrive_db_fetch_files_modified_at.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_gdrive_db_fetch_files_modified_at.py
@@ -1,13 +1,15 @@
 from datetime import datetime
 from unittest import TestCase
+import pytest
 
 import psycopg2
 from hivemind_etl_helpers.src.db.gdrive.db_utils import fetch_files_date_field, setup_db
-from llama_index import Document
+from llama_index.core import Document
 from tc_hivemind_backend.db.credentials import load_postgres_credentials
 from tc_hivemind_backend.pg_vector_access import PGVectorAccess
 
 
+@pytest.mark.skip(reason="GDrive ETL is not finished!")
 class TestFetchGdriveFileIds(TestCase):
     def setUpDB(self, community: str):
         db_name = f"community_{community}"

--- a/dags/hivemind_etl_helpers/tests/integration/test_gdrive_delete_records.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_gdrive_delete_records.py
@@ -1,15 +1,17 @@
 from datetime import datetime
 from unittest import TestCase
+import pytest
 
 import psycopg2
 from hivemind_etl_helpers.src.db.gdrive.db_utils import setup_db
 from hivemind_etl_helpers.src.db.gdrive.delete_records import delete_records
-from llama_index import Document
+from llama_index.core import Document
 from tc_hivemind_backend.db.credentials import load_postgres_credentials
 from tc_hivemind_backend.db.pg_db_utils import convert_tuple_str
 from tc_hivemind_backend.pg_vector_access import PGVectorAccess
 
 
+@pytest.mark.skip(reason="GDrive ETL is not finished!")
 class TestDeleteRecords(TestCase):
     def setUpDB(self, community_id: str):
         db_name = f"community_{community_id}"

--- a/dags/hivemind_etl_helpers/tests/integration/test_gdrive_documents_to_delete.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_gdrive_documents_to_delete.py
@@ -1,14 +1,16 @@
 from datetime import datetime
 from unittest import TestCase
+import pytest
 
 import psycopg2
 from hivemind_etl_helpers.src.db.gdrive.db_utils import setup_db
 from hivemind_etl_helpers.src.utils.check_documents import check_documents
-from llama_index import Document
+from llama_index.core import Document
 from tc_hivemind_backend.db.credentials import load_postgres_credentials
 from tc_hivemind_backend.pg_vector_access import PGVectorAccess
 
 
+@pytest.mark.skip(reason="GDrive ETL is not finished!")
 class TestGdriveDocumentsToDelete(TestCase):
     def setUpDB(self, community_id: str):
         db_name = f"community_{community_id}"

--- a/dags/hivemind_etl_helpers/tests/integration/test_gdrive_documents_to_insert.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_gdrive_documents_to_insert.py
@@ -1,14 +1,16 @@
 from datetime import datetime
 from unittest import TestCase
+import pytest
 
 import psycopg2
 from hivemind_etl_helpers.src.db.gdrive.db_utils import setup_db
 from hivemind_etl_helpers.src.utils.check_documents import check_documents
-from llama_index import Document
+from llama_index.core import Document
 from tc_hivemind_backend.db.credentials import load_postgres_credentials
 from tc_hivemind_backend.pg_vector_access import PGVectorAccess
 
 
+@pytest.mark.skip(reason="GDrive ETL is not finished!")
 class TestGdriveDocumentsToInsert(TestCase):
     def setUpDB(self, community_id: str):
         db_name = f"community_{community_id}"

--- a/dags/hivemind_etl_helpers/tests/integration/test_pg_vector_access_with_discord.py
+++ b/dags/hivemind_etl_helpers/tests/integration/test_pg_vector_access_with_discord.py
@@ -7,7 +7,7 @@ from hivemind_etl_helpers.src.db.discord.discord_raw_message_to_document import 
     discord_raw_to_docuemnts,
 )
 from hivemind_etl_helpers.src.utils.mongo import MongoSingleton
-from llama_index.indices.vector_store import VectorStoreIndex
+from llama_index.core.indices.vector_store import VectorStoreIndex
 from tc_hivemind_backend.db.credentials import load_postgres_credentials
 from tc_hivemind_backend.db.pg_db_utils import setup_db
 from tc_hivemind_backend.pg_vector_access import PGVectorAccess

--- a/dags/hivemind_etl_helpers/tests/unit/test_discourse_summary_prepare_category.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_discourse_summary_prepare_category.py
@@ -3,16 +3,15 @@ import unittest
 from hivemind_etl_helpers.src.db.discourse.summary.prepare_summary import (
     DiscourseSummary,
 )
-from llama_index import Document, MockEmbedding, ServiceContext
-from llama_index.llms import MockLLM
+from llama_index.core import Document, MockEmbedding, Settings
+from llama_index.core.llms import MockLLM
 
 
 class TestDiscoursePrepareDailySummaries(unittest.TestCase):
     def setUp(self):
-        self.mock_llm = MockLLM()
-        self.service_context = ServiceContext.from_defaults(
-            llm=MockLLM(), chunk_size=256, embed_model=MockEmbedding(embed_dim=1024)
-        )
+        Settings.llm = MockLLM()
+        Settings.chunk_size = 256
+        Settings.embed_model = MockEmbedding(embed_dim=1024)
 
     def test_prepare_daily_summaries_empty_data(self):
         self.setUp()
@@ -20,8 +19,6 @@ class TestDiscoursePrepareDailySummaries(unittest.TestCase):
         forum_endpoint = "sample_endpoint"
 
         prepare_summaries = DiscourseSummary(
-            service_context=self.service_context,
-            llm=self.mock_llm,
             forum_id=forum_id,
             forum_endpoint=forum_endpoint,
         )
@@ -40,8 +37,6 @@ class TestDiscoursePrepareDailySummaries(unittest.TestCase):
         forum_endpoint = "sample_endpoint"
 
         prepare_summaries = DiscourseSummary(
-            service_context=self.service_context,
-            llm=self.mock_llm,
             forum_id=forum_id,
             forum_endpoint=forum_endpoint,
         )
@@ -80,8 +75,6 @@ class TestDiscoursePrepareDailySummaries(unittest.TestCase):
         forum_endpoint = "sample_endpoint"
 
         prepare_summaries = DiscourseSummary(
-            service_context=self.service_context,
-            llm=self.mock_llm,
             forum_id=forum_id,
             forum_endpoint=forum_endpoint,
         )

--- a/dags/hivemind_etl_helpers/tests/unit/test_discourse_summary_prepare_daily.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_discourse_summary_prepare_daily.py
@@ -3,16 +3,15 @@ import unittest
 from hivemind_etl_helpers.src.db.discourse.summary.prepare_summary import (
     DiscourseSummary,
 )
-from llama_index import Document, MockEmbedding, ServiceContext
-from llama_index.llms import MockLLM
+from llama_index.core import Document, MockEmbedding, Settings
+from llama_index.core.llms import MockLLM
 
 
 class TestDiscoursePrepareCategorySummaries(unittest.TestCase):
     def setUp(self):
-        self.mock_llm = MockLLM()
-        self.service_context = ServiceContext.from_defaults(
-            llm=MockLLM(), chunk_size=256, embed_model=MockEmbedding(embed_dim=1024)
-        )
+        Settings.llm = MockLLM()
+        Settings.chunk_size = 256
+        Settings.embed_model = MockEmbedding(embed_dim=1024)
 
     def test_prepare_category_summaries_empty_data(self):
         self.setUp()
@@ -20,8 +19,6 @@ class TestDiscoursePrepareCategorySummaries(unittest.TestCase):
         forum_endpoint = "sample_endpoint"
 
         prepare_summaries = DiscourseSummary(
-            service_context=self.service_context,
-            llm=self.mock_llm,
             forum_id=forum_id,
             forum_endpoint=forum_endpoint,
         )
@@ -40,8 +37,6 @@ class TestDiscoursePrepareCategorySummaries(unittest.TestCase):
         forum_endpoint = "sample_endpoint"
 
         prepare_summaries = DiscourseSummary(
-            service_context=self.service_context,
-            llm=self.mock_llm,
             forum_id=forum_id,
             forum_endpoint=forum_endpoint,
         )
@@ -105,8 +100,6 @@ class TestDiscoursePrepareCategorySummaries(unittest.TestCase):
         forum_endpoint = "sample_endpoint"
 
         prepare_summaries = DiscourseSummary(
-            service_context=self.service_context,
-            llm=self.mock_llm,
             forum_id=forum_id,
             forum_endpoint=forum_endpoint,
         )

--- a/dags/hivemind_etl_helpers/tests/unit/test_discourse_summary_prepare_daily_documents.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_discourse_summary_prepare_daily_documents.py
@@ -3,16 +3,15 @@ import unittest
 from hivemind_etl_helpers.src.db.discourse.summary.prepare_summary import (
     DiscourseSummary,
 )
-from llama_index import Document, MockEmbedding, ServiceContext
-from llama_index.llms import MockLLM
+from llama_index.core import Document, MockEmbedding, Settings
+from llama_index.core.llms import MockLLM
 
 
 class TestDiscoursePrepareDailySummaryDocuments(unittest.TestCase):
     def setUp(self):
-        self.mock_llm = MockLLM()
-        self.service_context = ServiceContext.from_defaults(
-            llm=MockLLM(), chunk_size=256, embed_model=MockEmbedding(embed_dim=1024)
-        )
+        Settings.llm = MockLLM()
+        Settings.chunk_size = 256
+        Settings.embed_model = MockEmbedding(embed_dim=1024)
 
     def test_prepare_documents_empty_input(self):
         self.setUp()
@@ -20,8 +19,6 @@ class TestDiscoursePrepareDailySummaryDocuments(unittest.TestCase):
         forum_endpoint = "sample_endpoint"
 
         prepare_summaries = DiscourseSummary(
-            service_context=self.service_context,
-            llm=self.mock_llm,
             forum_id=forum_id,
             forum_endpoint=forum_endpoint,
         )
@@ -36,8 +33,6 @@ class TestDiscoursePrepareDailySummaryDocuments(unittest.TestCase):
         forum_endpoint = "sample_endpoint"
 
         prepare_summaries = DiscourseSummary(
-            service_context=self.service_context,
-            llm=self.mock_llm,
             forum_id=forum_id,
             forum_endpoint=forum_endpoint,
         )

--- a/dags/hivemind_etl_helpers/tests/unit/test_discourse_summary_prepare_topic.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_discourse_summary_prepare_topic.py
@@ -4,16 +4,15 @@ import neo4j
 from hivemind_etl_helpers.src.db.discourse.summary.prepare_summary import (
     DiscourseSummary,
 )
-from llama_index import MockEmbedding, ServiceContext
-from llama_index.llms import MockLLM
+from llama_index.core import MockEmbedding, Settings
+from llama_index.core.llms import MockLLM
 
 
 class TestDiscoursePrepareTopicSummaries(unittest.TestCase):
     def setUp(self):
-        self.mock_llm = MockLLM()
-        self.service_context = ServiceContext.from_defaults(
-            llm=MockLLM(), chunk_size=256, embed_model=MockEmbedding(embed_dim=1024)
-        )
+        Settings.llm = MockLLM()
+        Settings.chunk_size = 256
+        Settings.embed_model = MockEmbedding(embed_dim=1024)
 
     def test_prepare_topic_summaries_empty_data(self):
         self.setUp()
@@ -21,8 +20,6 @@ class TestDiscoursePrepareTopicSummaries(unittest.TestCase):
         forum_endpoint = "sample_endpoint"
 
         prepare_summaries = DiscourseSummary(
-            service_context=self.service_context,
-            llm=self.mock_llm,
             forum_id=forum_id,
             forum_endpoint=forum_endpoint,
         )
@@ -67,8 +64,6 @@ class TestDiscoursePrepareTopicSummaries(unittest.TestCase):
             raw_data_grouped.append(data)
 
         prepare_summaries = DiscourseSummary(
-            service_context=self.service_context,
-            llm=self.mock_llm,
             forum_id=forum_id,
             forum_endpoint=forum_endpoint,
         )

--- a/dags/hivemind_etl_helpers/tests/unit/test_gdrive_files_modified_at_process_results.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_gdrive_files_modified_at_process_results.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 from unittest import TestCase
+import pytest
 
 from hivemind_etl_helpers.src.db.gdrive.db_utils import postprocess_results
 
 
+@pytest.mark.skip(reason="GDrive ETL is not finished!")
 class TestProcessGdriveFileRetreivalResultsProcess(TestCase):
     def test_empty_list(self):
         self.assertEqual(postprocess_results([]), {})

--- a/dags/hivemind_etl_helpers/tests/unit/test_github_etl_prepare_deletion.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_github_etl_prepare_deletion.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 from hivemind_etl_helpers.src.db.github.load import PrepareDeletion
-from llama_index import Document
+from llama_index.core import Document
 
 
 class TestPrepareDeletion(unittest.TestCase):

--- a/dags/hivemind_etl_helpers/tests/unit/test_github_transform_comments.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_github_transform_comments.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from hivemind_etl_helpers.src.db.github.schema import GitHubComment
 from hivemind_etl_helpers.src.db.github.transform.comments import transform_comments
-from llama_index import Document
+from llama_index.core import Document
 
 
 class TestGithubTransformcomComments(TestCase):

--- a/dags/hivemind_etl_helpers/tests/unit/test_github_transform_commits.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_github_transform_commits.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from hivemind_etl_helpers.src.db.github.schema import GitHubCommit
 from hivemind_etl_helpers.src.db.github.transform.commits import transform_commits
-from llama_index import Document
+from llama_index.core import Document
 
 
 class TestGithubTransformCommits(TestCase):

--- a/dags/hivemind_etl_helpers/tests/unit/test_github_transform_issues.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_github_transform_issues.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from hivemind_etl_helpers.src.db.github.schema import GitHubIssue
 from hivemind_etl_helpers.src.db.github.transform.issues import transform_issues
-from llama_index import Document
+from llama_index.core import Document
 
 
 class TestGithubTransformIssues(TestCase):

--- a/dags/hivemind_etl_helpers/tests/unit/test_github_transform_prs.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_github_transform_prs.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from hivemind_etl_helpers.src.db.github.schema import GitHubPullRequest
 from hivemind_etl_helpers.src.db.github.transform.pull_requests import transform_prs
-from llama_index import Document
+from llama_index.core import Document
 
 
 class TestGithubTransformPRs(TestCase):

--- a/dags/hivemind_etl_helpers/tests/unit/test_sort_summary_docs.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_sort_summary_docs.py
@@ -1,7 +1,7 @@
 import unittest
 
 from hivemind_etl_helpers.src.utils.sort_summary_docs import sort_summaries_daily
-from llama_index import Document
+from llama_index.core import Document
 
 
 class TestSortSummariesDaily(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy
-llama-index==0.9.48
 pymongo
 python-dotenv
 pgvector
@@ -17,5 +16,5 @@ coverage>=7.3.3, <8.0.0
 pytest>=7.4.3, <8.0.0
 python-dotenv>=1.0.0, <2.0.0
 urlextract==1.8.0
-tc-hivemind-backend==1.1.3
+tc-hivemind-backend==1.1.4
 traceloop-sdk==0.9.4


### PR DESCRIPTION
- We needed to update codes based on the latest update of llama-index library.
- We also, added skip to previously gdrive etl test cases as because the task was paused and yet to be completed.