### PR TITLE
fix: skipping files with null sha!

### DIFF
--- a/dags/github/neo4j_storage/commits.py
+++ b/dags/github/neo4j_storage/commits.py
@@ -69,6 +69,7 @@ def save_commit_files_changes_to_neo4j(
                 (c:{Node.Commit.value} {{sha: $commit_sha}})
                 WITH repo, c
                 UNWIND $file_changes AS file_change
+                WHERE file_change.sha IS NOT NULL
                 MERGE (f:{Node.File.value} {{sha: file_change.sha, filename: file_change.filename}})
                     SET f += file_change, f.latestSavedAt = datetime()
                 MERGE (c)-[fc:{Relationship.CHANGED.value}]->(f)


### PR DESCRIPTION
In case of some files having no changes, the sha will be null and this could cause the query to break.