### PR TITLE
fix: media wiki modules fetching!

### DIFF
--- a/dags/hivemind_etl_helpers/src/utils/modules/mediawiki.py
+++ b/dags/hivemind_etl_helpers/src/utils/modules/mediawiki.py
@@ -37,16 +37,16 @@ class ModulesMediaWiki(ModulesBase):
                 if platform["name"] != self.platform_name:
                     continue
 
-                page_ids = self.get_platform_metadata(
+                base_url = self.get_platform_metadata(
                     platform_id=platform["platform"],
-                    metadata_name="pageIds",
+                    metadata_name="baseURL",
                 )
                 modules_options = platform["metadata"]
                 communities_data.append(
                     {
                         "community_id": str(community),
-                        "page_titles": page_ids,
-                        "base_url": modules_options.get("api_url"),
+                        "page_titles": modules_options.get("pageIds", []),
+                        "base_url": base_url,
                     }
                 )
 


### PR DESCRIPTION
the page ids were on modules and it was the base_url on platform document.