### PR TITLE
fix: introduced patched version of tc-wikipedia-lib as we were having…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,6 @@ llama-index-readers-google==0.2.5
 llama-index-storage-docstore-redis==0.1.2
 llama-index-storage-docstore-mongodb==0.1.3
 redis===5.0.4
-tc-wikipedia-lib==1.0.0
+tc-wikipedia-lib==1.0.1
 llama-index-readers-file==0.1.22
 docx2txt==0.8


### PR DESCRIPTION
… issues with extraction from `WikiTravel` and `Commons Wikimedia`;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `tc-wikipedia-lib` to version `1.0.1` for improved performance and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->