### PR TITLE
fix: avoid parallel DAG run & disabling catchup!

### DIFF
--- a/dags/github.py
+++ b/dags/github.py
@@ -64,6 +64,7 @@ with DAG(
     start_date=datetime(2022, 12, 1, 14),
     schedule_interval=timedelta(hours=6),
     catchup=False,
+    max_active_runs=1,
 ) as dag:
 
     @task

--- a/dags/hivemind_discord_etl.py
+++ b/dags/hivemind_discord_etl.py
@@ -15,6 +15,7 @@ with DAG(
     start_date=datetime(2024, 1, 1),
     schedule_interval="0 2 * * *",
     catchup=False,
+    max_active_runs=1,
 ) as dag:
 
     @task
@@ -56,6 +57,8 @@ with DAG(
     dag_id="discord_summary_vector_store",
     start_date=datetime(2024, 1, 1),
     schedule_interval="0 2 * * *",
+    catchup=False,
+    max_active_runs=1,
 ) as dag:
 
     @task

--- a/dags/hivemind_discourse_etl.py
+++ b/dags/hivemind_discourse_etl.py
@@ -11,6 +11,8 @@ with DAG(
     dag_id="discourse_vector_store",
     start_date=datetime(2024, 3, 1),
     schedule_interval="0 2 * * *",
+    catchup=False,
+    max_active_runs=1,
 ) as dag:
 
     @task
@@ -39,7 +41,10 @@ with DAG(
     dag_id="discourse_summary_vector_store",
     start_date=datetime(2024, 2, 21),
     schedule_interval="0 2 * * *",
+    catchup=False,
+    max_active_runs=1,
 ) as dag:
+    dag.max_active_runs = 1
 
     @task
     def get_discourse_communities_info():

--- a/dags/hivemind_github_etl.py
+++ b/dags/hivemind_github_etl.py
@@ -12,6 +12,8 @@ with DAG(
     dag_id="github_vector_store",
     start_date=datetime(2024, 2, 21),
     schedule_interval="0 2 * * *",
+    catchup=False,
+    max_active_runs=1,
 ) as dag:
 
     @task

--- a/dags/hivemind_google_drive_etl.py
+++ b/dags/hivemind_google_drive_etl.py
@@ -13,6 +13,8 @@ with DAG(
     dag_id="gdrive_vector_store",
     start_date=datetime(2024, 2, 21),
     schedule_interval="0 4 * * *",
+    catchup=False,
+    max_active_runs=1,
 ) as dag:
 
     @task

--- a/dags/hivemind_mediawiki_etl.py
+++ b/dags/hivemind_mediawiki_etl.py
@@ -12,6 +12,8 @@ with DAG(
     dag_id="mediawiki_vector_store_update",
     start_date=datetime(2024, 2, 21),
     schedule_interval="0 4 * * *",
+    catchup=False,
+    max_active_runs=1,
 ) as dag:
 
     @task

--- a/dags/hivemind_notion_etl.py
+++ b/dags/hivemind_notion_etl.py
@@ -12,6 +12,8 @@ with DAG(
     dag_id="notion_vector_store_update",
     start_date=datetime(2024, 2, 21),
     schedule_interval="0 4 * * *",
+    catchup=False,
+    max_active_runs=1,
 ) as dag:
 
     @task


### PR DESCRIPTION
+ the catchup was for running multiple instances of a DAG in case the DAG ran on very old past.
+ the parallel avoiding was because we're doing ETL job and if we ran multiple times, we could end up in having duplicate data