### PR TITLE
[GITHUB] fix: the API call should be using the org login info!

### DIFF
--- a/dags/github.py
+++ b/dags/github.py
@@ -146,9 +146,9 @@ with DAG(
             logging.info(
                 "Extracting organization members iteration "
                 f"{iter + 1}/{len(organization['organizations_info'])} | "
-                f"org name: `{org['name']}` members"
+                f"org name: `{org['login']}` members"
             )
-            org_name = org["name"]
+            org_name = org["login"]
             members = get_all_org_members(org=org_name)
             org["members"] = members
 
@@ -182,7 +182,7 @@ with DAG(
                 f"Iter {i + 1}/{len(organizations)} | "
                 f"extracting github org {org['name']} repos!"
             )
-            repos = get_all_org_repos(org_name=org["name"])
+            repos = get_all_org_repos(org_name=org["login"])
             org["repos"] = repos
 
         return organizations


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected GitHub organization name references to ensure accurate data extraction for organization members and repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->