### PR TITLE
fix: wrong return type for fetch_analyzer_parameters and missing retu…

### DIFF
--- a/dags/all_discord_guilds_analyzer_etl.py
+++ b/dags/all_discord_guilds_analyzer_etl.py
@@ -225,7 +225,7 @@ with DAG(
             period=period,
             action=action,
             window=window,
-            recompute=recompute
+            recompute=recompute,
         )
 
     platform_modules = fetch_discord_platforms()

--- a/dags/all_discord_guilds_analyzer_etl.py
+++ b/dags/all_discord_guilds_analyzer_etl.py
@@ -137,6 +137,8 @@ with DAG(
         else:
             logging.info("No new data to load!")
 
+        return platform_info
+
     @task
     def discord_etl_raw_members(
         platform_info: dict[str, str | datetime | bool]
@@ -216,19 +218,19 @@ with DAG(
         window = metadata["window"]
         channels = metadata["selectedChannels"]
 
-        analyzer = Analyzer(
+        analyzer = Analyzer()
+        analyzer.analyze(
             platform_id=platform_id,
             channels=channels,
             period=period,
             action=action,
             window=window,
-            recompute=recompute,
+            recompute=recompute
         )
-        analyzer.analyze(recompute=recompute)
 
     platform_modules = fetch_discord_platforms()
 
     raw_data_etl = discord_etl_raw_data.expand(platform_info=platform_modules)
     raw_members_etl = discord_etl_raw_members.expand(platform_info=platform_modules)
 
-    raw_members_etl >> analyze_discord(platform_processed=raw_data_etl)
+    raw_members_etl >> analyze_discord.expand(platform_processed=raw_data_etl)

--- a/dags/analyzer_helper/discord/fetch_discord_platforms.py
+++ b/dags/analyzer_helper/discord/fetch_discord_platforms.py
@@ -107,7 +107,6 @@ class FetchDiscordPlatforms:
                 f"No platform given platform_id: {platform_id} is available!"
             )
 
-
     # TODO: Decide if we'd like to merge `fetch_all` and `fetch_analyzer_parameters`
     # def fetch_for_analyzer(self, platform_id: str):
     #     """

--- a/dags/analyzer_helper/discord/fetch_discord_platforms.py
+++ b/dags/analyzer_helper/discord/fetch_discord_platforms.py
@@ -58,7 +58,7 @@ class FetchDiscordPlatforms:
 
         return platforms
 
-    def fetch_analyzer_parameters(self, platform_id: str):
+    def fetch_analyzer_parameters(self, platform_id: str) -> dict:
         """
         Fetches the specified Discord platform from the MongoDB collection with additional fields.
 
@@ -85,26 +85,28 @@ class FetchDiscordPlatforms:
             "metadata.id": 1,
         }
 
-        cursor = self.collection.find(query, projection)
-        platforms = []
+        platform = self.collection.find_one(query, projection)
 
-        for doc in cursor:
+        if platform is not None:
             platform_data = {
-                "platform_id": str(doc["_id"]),
+                "platform_id": str(platform["_id"]),
                 "metadata": {
-                    "period": doc.get("metadata", {}).get("period", None),
-                    "action": doc.get("metadata", {}).get("action", None),
-                    "window": doc.get("metadata", {}).get("window", None),
-                    "selectedChannels": doc.get("metadata", {}).get(
+                    "period": platform.get("metadata", {}).get("period", None),
+                    "action": platform.get("metadata", {}).get("action", None),
+                    "window": platform.get("metadata", {}).get("window", None),
+                    "selectedChannels": platform.get("metadata", {}).get(
                         "selectedChannels", None
                     ),
-                    "id": doc.get("metadata", {}).get("id", None),
+                    "id": platform.get("metadata", {}).get("id", None),
                 },
                 "recompute": False,
             }
-            platforms.append(platform_data)
+            return platform_data
+        else:
+            raise ValueError(
+                f"No platform given platform_id: {platform_id} is available!"
+            )
 
-        return platforms
 
     # TODO: Decide if we'd like to merge `fetch_all` and `fetch_analyzer_parameters`
     # def fetch_for_analyzer(self, platform_id: str):

--- a/dags/analyzer_helper/tests/integration/test_integration_fetch_discord_platforms.py
+++ b/dags/analyzer_helper/tests/integration/test_integration_fetch_discord_platforms.py
@@ -390,11 +390,9 @@ class TestFetchDiscordPlatforms(unittest.TestCase):
 
         platform_id = ObjectId("000000000000000000000001")
 
-        result = fetcher.fetch_analyzer_parameters(platform_id)
-
-        expected_result = []
-
-        self.assertEqual(result, expected_result)
+        # no results is given
+        with self.assertRaises(ValueError):
+            fetcher.fetch_analyzer_parameters(platform_id)
 
     def test_get_single_data_fetch_all(self):
         sample_data = {
@@ -445,12 +443,14 @@ class TestFetchDiscordPlatforms(unittest.TestCase):
 
         result = fetcher.fetch_all()
 
-        expected_result = {
-            "platform_id": str(sample_data["_id"]),
-            "period": datetime(2023, 10, 20),
-            "recompute": False,
-            "guild_id": "777777777777777",
-        }
+        expected_result = [
+            {
+                "platform_id": str(sample_data["_id"]),
+                "period": datetime(2023, 10, 20),
+                "recompute": False,
+                "guild_id": "777777777777777",
+            }
+        ]
         self.assertEqual(result, expected_result)
 
     def test_get_single_data_fetch_analyzer_parameters(self):

--- a/dags/analyzer_helper/tests/integration/test_integration_fetch_discord_platforms.py
+++ b/dags/analyzer_helper/tests/integration/test_integration_fetch_discord_platforms.py
@@ -298,7 +298,7 @@ class TestFetchDiscordPlatforms(unittest.TestCase):
             platform_id=second_platform_id
         )
 
-        result = result_first_platform + result_second_platform
+        result = [result_first_platform, result_second_platform]
 
         expected_result = [
             {
@@ -445,14 +445,12 @@ class TestFetchDiscordPlatforms(unittest.TestCase):
 
         result = fetcher.fetch_all()
 
-        expected_result = [
-            {
-                "platform_id": str(sample_data["_id"]),
-                "period": datetime(2023, 10, 20),
-                "recompute": False,
-                "guild_id": "777777777777777",
-            }
-        ]
+        expected_result = {
+            "platform_id": str(sample_data["_id"]),
+            "period": datetime(2023, 10, 20),
+            "recompute": False,
+            "guild_id": "777777777777777",
+        }
         self.assertEqual(result, expected_result)
 
     def test_get_single_data_fetch_analyzer_parameters(self):
@@ -506,42 +504,40 @@ class TestFetchDiscordPlatforms(unittest.TestCase):
 
         result = fetcher.fetch_analyzer_parameters(platform_id=platform_id)
 
-        expected_result = [
-            {
-                "platform_id": str(sample_data["_id"]),
-                "metadata": {
-                    "action": {
-                        "INT_THR": 1,
-                        "UW_DEG_THR": 1,
-                        "PAUSED_T_THR": 1,
-                        "CON_T_THR": 4,
-                        "CON_O_THR": 3,
-                        "EDGE_STR_THR": 5,
-                        "UW_THR_DEG_THR": 5,
-                        "VITAL_T_THR": 4,
-                        "VITAL_O_THR": 3,
-                        "STILL_T_THR": 2,
-                        "STILL_O_THR": 2,
-                        "DROP_H_THR": 2,
-                        "DROP_I_THR": 1,
-                    },
-                    "window": {"period_size": 7, "step_size": 1},
-                    "id": "777777777777777",
-                    # "isInProgress": False,
-                    "period": datetime(2023, 10, 20),
-                    # "icon": "e160861192ed8c2a6fa65a8ab6ac337e",
-                    "selectedChannels": [
-                        "1067517728543477920",
-                        "1067512760163897514",
-                        "1177090385307254844",
-                        "1177728302123851846",
-                        "1194381466663141519",
-                        "1194381535734935602",
-                    ],
-                    # "name": "PlatformName",
-                    # "analyzerStartedAt": datetime(2024, 4, 17, 13, 29, 16, 157000),
+        expected_result = {
+            "platform_id": str(sample_data["_id"]),
+            "metadata": {
+                "action": {
+                    "INT_THR": 1,
+                    "UW_DEG_THR": 1,
+                    "PAUSED_T_THR": 1,
+                    "CON_T_THR": 4,
+                    "CON_O_THR": 3,
+                    "EDGE_STR_THR": 5,
+                    "UW_THR_DEG_THR": 5,
+                    "VITAL_T_THR": 4,
+                    "VITAL_O_THR": 3,
+                    "STILL_T_THR": 2,
+                    "STILL_O_THR": 2,
+                    "DROP_H_THR": 2,
+                    "DROP_I_THR": 1,
                 },
-                "recompute": False,
-            }
-        ]
+                "window": {"period_size": 7, "step_size": 1},
+                "id": "777777777777777",
+                # "isInProgress": False,
+                "period": datetime(2023, 10, 20),
+                # "icon": "e160861192ed8c2a6fa65a8ab6ac337e",
+                "selectedChannels": [
+                    "1067517728543477920",
+                    "1067512760163897514",
+                    "1177090385307254844",
+                    "1177728302123851846",
+                    "1194381466663141519",
+                    "1194381535734935602",
+                ],
+                # "name": "PlatformName",
+                # "analyzerStartedAt": datetime(2024, 4, 17, 13, 29, 16, 157000),
+            },
+            "recompute": False,
+        }
         self.assertEqual(result, expected_result)

--- a/dags/analyzer_helper/tests/unit/test_unit_fetch_discord_platforms.py
+++ b/dags/analyzer_helper/tests/unit/test_unit_fetch_discord_platforms.py
@@ -126,51 +126,49 @@ class TestFetchDiscordPlatformsUnit(unittest.TestCase):
         mock_db = mock_client["Core"]
         mock_collection = mock_db["platforms"]
 
-        sample_data = [
-            {
-                "_id": ObjectId("000000000000000000000001"),
-                "platform": "discord",
-                "metadata": {
-                    "action": {
-                        "INT_THR": 1,
-                        "UW_DEG_THR": 1,
-                        "PAUSED_T_THR": 1,
-                        "CON_T_THR": 4,
-                        "CON_O_THR": 3,
-                        "EDGE_STR_THR": 5,
-                        "UW_THR_DEG_THR": 5,
-                        "VITAL_T_THR": 4,
-                        "VITAL_O_THR": 3,
-                        "STILL_T_THR": 2,
-                        "STILL_O_THR": 2,
-                        "DROP_H_THR": 2,
-                        "DROP_I_THR": 1,
-                    },
-                    "window": {"period_size": 7, "step_size": 1},
-                    "id": "777777777777777",
-                    "isInProgress": False,
-                    "period": datetime(2023, 10, 20),
-                    "icon": "e160861192ed8c2a6fa65a8ab6ac337e",
-                    "selectedChannels": [
-                        "1067517728543477920",
-                        "1067512760163897514",
-                        "1177090385307254844",
-                        "1177728302123851846",
-                        "1194381466663141519",
-                        "1194381535734935602",
-                    ],
-                    "name": "PlatformName",
-                    "analyzerStartedAt": datetime(2024, 4, 17, 13, 29, 16, 157000),
+        sample_data = {
+            "_id": ObjectId("000000000000000000000001"),
+            "platform": "discord",
+            "metadata": {
+                "action": {
+                    "INT_THR": 1,
+                    "UW_DEG_THR": 1,
+                    "PAUSED_T_THR": 1,
+                    "CON_T_THR": 4,
+                    "CON_O_THR": 3,
+                    "EDGE_STR_THR": 5,
+                    "UW_THR_DEG_THR": 5,
+                    "VITAL_T_THR": 4,
+                    "VITAL_O_THR": 3,
+                    "STILL_T_THR": 2,
+                    "STILL_O_THR": 2,
+                    "DROP_H_THR": 2,
+                    "DROP_I_THR": 1,
                 },
-                "community": "6579c364f1120850414e0dc5",
-                "disconnectedAt": None,
-                "connectedAt": datetime(2023, 7, 7, 8, 47, 49, 96000),
-                "createdAt": datetime(2023, 12, 22, 8, 49, 48, 677000),
-                "updatedAt": datetime(2024, 6, 5, 0, 0, 1, 984000),
+                "window": {"period_size": 7, "step_size": 1},
+                "id": "777777777777777",
+                "isInProgress": False,
+                "period": datetime(2023, 10, 20),
+                "icon": "e160861192ed8c2a6fa65a8ab6ac337e",
+                "selectedChannels": [
+                    "1067517728543477920",
+                    "1067512760163897514",
+                    "1177090385307254844",
+                    "1177728302123851846",
+                    "1194381466663141519",
+                    "1194381535734935602",
+                ],
+                "name": "PlatformName",
+                "analyzerStartedAt": datetime(2024, 4, 17, 13, 29, 16, 157000),
             },
-        ]
+            "community": "6579c364f1120850414e0dc5",
+            "disconnectedAt": None,
+            "connectedAt": datetime(2023, 7, 7, 8, 47, 49, 96000),
+            "createdAt": datetime(2023, 12, 22, 8, 49, 48, 677000),
+            "updatedAt": datetime(2024, 6, 5, 0, 0, 1, 984000),
+        }
 
-        mock_collection.find.return_value = sample_data
+        mock_collection.find_one.return_value = sample_data
         mock_get_instance.return_value = MagicMock(client=mock_client)
 
         fetcher = FetchDiscordPlatforms()
@@ -179,44 +177,42 @@ class TestFetchDiscordPlatformsUnit(unittest.TestCase):
 
         result = fetcher.fetch_analyzer_parameters(platform_id_first)
 
-        expected_result = [
-            {
-                "platform_id": str(sample_data[0]["_id"]),
-                "metadata": {
-                    "action": {
-                        "INT_THR": 1,
-                        "UW_DEG_THR": 1,
-                        "PAUSED_T_THR": 1,
-                        "CON_T_THR": 4,
-                        "CON_O_THR": 3,
-                        "EDGE_STR_THR": 5,
-                        "UW_THR_DEG_THR": 5,
-                        "VITAL_T_THR": 4,
-                        "VITAL_O_THR": 3,
-                        "STILL_T_THR": 2,
-                        "STILL_O_THR": 2,
-                        "DROP_H_THR": 2,
-                        "DROP_I_THR": 1,
-                    },
-                    "window": {"period_size": 7, "step_size": 1},
-                    "id": "777777777777777",
-                    # "isInProgress": False,
-                    "period": datetime(2023, 10, 20),
-                    # "icon": "e160861192ed8c2a6fa65a8ab6ac337e",
-                    "selectedChannels": [
-                        "1067517728543477920",
-                        "1067512760163897514",
-                        "1177090385307254844",
-                        "1177728302123851846",
-                        "1194381466663141519",
-                        "1194381535734935602",
-                    ],
-                    # "name": "PlatformName",
-                    # "analyzerStartedAt": datetime(2024, 4, 17, 13, 29, 16, 157000),
+        expected_result = {
+            "platform_id": str(sample_data["_id"]),
+            "metadata": {
+                "action": {
+                    "INT_THR": 1,
+                    "UW_DEG_THR": 1,
+                    "PAUSED_T_THR": 1,
+                    "CON_T_THR": 4,
+                    "CON_O_THR": 3,
+                    "EDGE_STR_THR": 5,
+                    "UW_THR_DEG_THR": 5,
+                    "VITAL_T_THR": 4,
+                    "VITAL_O_THR": 3,
+                    "STILL_T_THR": 2,
+                    "STILL_O_THR": 2,
+                    "DROP_H_THR": 2,
+                    "DROP_I_THR": 1,
                 },
-                "recompute": False,
+                "window": {"period_size": 7, "step_size": 1},
+                "id": "777777777777777",
+                # "isInProgress": False,
+                "period": datetime(2023, 10, 20),
+                # "icon": "e160861192ed8c2a6fa65a8ab6ac337e",
+                "selectedChannels": [
+                    "1067517728543477920",
+                    "1067512760163897514",
+                    "1177090385307254844",
+                    "1177728302123851846",
+                    "1194381466663141519",
+                    "1194381535734935602",
+                ],
+                # "name": "PlatformName",
+                # "analyzerStartedAt": datetime(2024, 4, 17, 13, 29, 16, 157000),
             },
-        ]
+            "recompute": False,
+        }
         print("Result: ", result)
         print("Expected result: ", expected_result)
         self.assertEqual(result, expected_result)
@@ -244,15 +240,12 @@ class TestFetchDiscordPlatformsUnit(unittest.TestCase):
         mock_db = mock_client["Core"]
         mock_collection = mock_db["platforms"]
 
-        mock_collection.find.return_value = []
+        mock_collection.find_one.return_value = None
         mock_get_instance.return_value = MagicMock(client=mock_client)
 
         fetcher = FetchDiscordPlatforms()
 
         platform_id = ObjectId("000000000000000000000001")
 
-        result = fetcher.fetch_analyzer_parameters(platform_id)
-
-        expected_result = []
-
-        self.assertEqual(result, expected_result)
+        with self.assertRaises(ValueError):
+            result = fetcher.fetch_analyzer_parameters(platform_id)


### PR DESCRIPTION
…rn statement in DAG task!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for fetching Discord platform data, ensuring an appropriate error is raised if no platform is found.
  
- **Tests**
  - Updated integration and unit tests to align with the new data-fetching logic, changing expected results from lists to dictionaries and adding error assertions for missing data.

- **Refactor**
  - Modified Discord ETL process to streamline platform data handling, returning `platform_info` directly and adjusting method calls accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->