### PR TITLE
feat: bump tc_analyzer_lib version!

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ redis===5.0.4
 tc-wikipedia-lib==1.0.1
 llama-index-readers-file==0.1.22
 docx2txt==0.8
-tc-analyzer-lib==1.1.1
+tc-analyzer-lib==1.2.0


### PR DESCRIPTION
It's for reducing the computation time of heatmaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `tc-analyzer-lib` to version `1.2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->