### PR TITLE
fix: discord_guild_etl, converting period to datetime!

### DIFF
--- a/dags/discord_guild_analyzer_etl.py
+++ b/dags/discord_guild_analyzer_etl.py
@@ -17,6 +17,7 @@ from analyzer_helper.discord.discord_transform_raw_members import (
     DiscordTransformRawMembers,
 )
 from analyzer_helper.discord.fetch_discord_platforms import FetchDiscordPlatforms
+from dateutil.parser import parse
 
 with DAG(
     dag_id="discord_guild_analyzer_etl",
@@ -63,7 +64,7 @@ with DAG(
         platform = {
             "recompute": recompute,
             "platform_id": platform_id,
-            "period": period,
+            "period": parse(period),
             "guild_id": guild_id,
         }
 


### PR DESCRIPTION
the period being passed via api to the DAG is not in datetime format, so we're converting it now.