### PR TITLE
fix: skipping None labels for reporting!

### DIFF
--- a/dags/violation_detection_helpers/utils/prepare_report.py
+++ b/dags/violation_detection_helpers/utils/prepare_report.py
@@ -27,9 +27,10 @@ class PrepareReport:
 
             if label and link:
                 # report for single document
-                doc_report = f"Document link: {link} | Label: {label}"
-
-                reports.append(doc_report)
+                # if there was a specific label
+                if label != "None":
+                    doc_report = f"Document link: {link} | Label: {label}"
+                    reports.append(doc_report)
             elif label:
                 logging.error(
                     f"Document with _id: {id} doesn't have "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced report generation logic to exclude documents with a label set to "None," leading to clearer and more accurate report outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->