### PR TITLE
fix: hivemind telegram ETL, data types and timestamp conversion!

### DIFF
--- a/dags/analyzer_helper/telegram/extract_raw_data.py
+++ b/dags/analyzer_helper/telegram/extract_raw_data.py
@@ -9,7 +9,7 @@ from hivemind_etl_helpers.src.utils.mongo import MongoSingleton
 
 
 class ExtractRawInfo:
-    def __init__(self, chat_id: str, platform_id: str):
+    def __init__(self, chat_id: int, platform_id: str):
         """
         Initialize the ExtractRawInfo with the forum endpoint, platform id and set up Neo4j and MongoDB connection.
         """

--- a/dags/analyzer_helper/telegram/extract_raw_members.py
+++ b/dags/analyzer_helper/telegram/extract_raw_members.py
@@ -7,7 +7,7 @@ from pymongo import DESCENDING
 
 
 class ExtractRawMembers:
-    def __init__(self, chat_id: str, platform_id: str):
+    def __init__(self, chat_id: int, platform_id: str):
         """
         Initialize the ExtractRawMembers with the Neo4j connection parameters.
         """

--- a/dags/analyzer_helper/telegram/tests/integration/test_telegram_extract_raw_data.py
+++ b/dags/analyzer_helper/telegram/tests/integration/test_telegram_extract_raw_data.py
@@ -12,7 +12,7 @@ class TestExtractRawInfo(unittest.TestCase):
         cls.neo4jConnection = Neo4jConnection()
         cls.client = MongoSingleton.get_instance().client
         cls.driver = cls.neo4jConnection.connect_neo4j()
-        cls.chat_id = "test_group"
+        cls.chat_id = 1234554321
         cls.platform_id = "platform_db"
         cls.platform_db = cls.client[cls.platform_id]
         cls.extractor = ExtractRawInfo(cls.chat_id, cls.platform_id)

--- a/dags/analyzer_helper/telegram/tests/integration/test_telegram_extract_raw_members.py
+++ b/dags/analyzer_helper/telegram/tests/integration/test_telegram_extract_raw_members.py
@@ -9,7 +9,7 @@ class TestExtractRawMembers(unittest.TestCase):
     def setUp(self):
         self.neo4jConnection = Neo4jConnection()
         self.driver = self.neo4jConnection.connect_neo4j()
-        self.chat_id = "telegram_test_group"
+        self.chat_id = 12345665432
         self.platform_id = "telegram_test_platform"
         self.extractor = ExtractRawMembers(self.chat_id, self.platform_id)
         self.rawmembers_collection = self.extractor.rawmembers_collection

--- a/dags/analyzer_helper/telegram/transform_raw_data.py
+++ b/dags/analyzer_helper/telegram/transform_raw_data.py
@@ -5,7 +5,7 @@ from analyzer_helper.telegram.utils.is_user_bot import UserBotChecker
 
 
 class TransformRawInfo:
-    def __init__(self, chat_id: str):
+    def __init__(self, chat_id: int):
         self.converter = DateTimeFormatConverter
         self.user_bot_checker = UserBotChecker()
         self.chat_id = chat_id

--- a/dags/hivemind_etl_helpers/src/db/telegram/extract/messages.py
+++ b/dags/hivemind_etl_helpers/src/db/telegram/extract/messages.py
@@ -5,7 +5,7 @@ from tc_neo4j_lib import Neo4jOps
 
 
 class ExtractMessages:
-    def __init__(self, chat_id: str) -> None:
+    def __init__(self, chat_id: int) -> None:
         self.chat_id = chat_id
         self._connection = Neo4jOps.get_instance()
 

--- a/dags/hivemind_etl_helpers/src/db/telegram/extract/messages_daily.py
+++ b/dags/hivemind_etl_helpers/src/db/telegram/extract/messages_daily.py
@@ -7,7 +7,7 @@ from . import ExtractMessages
 
 
 class ExtractMessagesDaily:
-    def __init__(self, chat_id: str) -> None:
+    def __init__(self, chat_id: int) -> None:
         self.extractor = ExtractMessages(chat_id=chat_id)
 
     def extract(
@@ -31,7 +31,7 @@ class ExtractMessagesDaily:
 
         daily_tg_messages: dict[date, list[TelegramMessagesModel]] = defaultdict(list)
         for msg in messages:
-            msg_date = datetime.fromtimestamp(msg.message_created_at / 1000).date()
+            msg_date = datetime.fromtimestamp(msg.message_created_at).date()
             daily_tg_messages[msg_date].append(msg)
 
         return daily_tg_messages

--- a/dags/hivemind_etl_helpers/src/db/telegram/transform/messages.py
+++ b/dags/hivemind_etl_helpers/src/db/telegram/transform/messages.py
@@ -3,7 +3,7 @@ from llama_index.core import Document
 
 
 class TransformMessages:
-    def __init__(self, chat_id: str, chat_name: str) -> None:
+    def __init__(self, chat_id: int, chat_name: str) -> None:
         self.chat_id = chat_id
         self.chat_name = chat_name
 

--- a/dags/hivemind_etl_helpers/src/db/telegram/transform/summarizer.py
+++ b/dags/hivemind_etl_helpers/src/db/telegram/transform/summarizer.py
@@ -10,7 +10,7 @@ from llama_index.core.response_synthesizers.base import BaseSynthesizer
 class SummarizeMessages(SummaryBase):
     def __init__(
         self,
-        chat_id: str,
+        chat_id: int,
         chat_name: str,
         response_synthesizer: BaseSynthesizer | None = None,
         verbose: bool = False,

--- a/dags/hivemind_etl_helpers/src/db/telegram/utils/platform.py
+++ b/dags/hivemind_etl_helpers/src/db/telegram/utils/platform.py
@@ -5,11 +5,11 @@ from hivemind_etl_helpers.src.utils.mongo import MongoSingleton
 
 
 class TelegramPlatform:
-    def __init__(self, chat_id: str, chat_name: str) -> None:
+    def __init__(self, chat_id: int, chat_name: str) -> None:
         """
         Parameters
         -----------
-        chat_id : str
+        chat_id : int
             check if there's any platform exists
         chat_name : str
             the chat name to create later (if not already exists)

--- a/dags/hivemind_etl_helpers/tests/unit/test_telegram_extract_daily_messages.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_telegram_extract_daily_messages.py
@@ -10,7 +10,7 @@ from hivemind_etl_helpers.src.db.telegram.schema import TelegramMessagesModel
 class TestExtractMessagesDaily(unittest.TestCase):
     def setUp(self):
         load_dotenv()
-        self.chat_id = "test_chat"
+        self.chat_id = 12344321
         self.extractor = ExtractMessagesDaily(chat_id=self.chat_id)
 
     @patch(
@@ -32,8 +32,8 @@ class TestExtractMessagesDaily(unittest.TestCase):
             message_id=1,
             message_text="Hello, World!",
             author_username="user1",
-            message_created_at=1633046400000.0,  # Equivalent to 2021-10-01T00:00:00 UTC
-            message_edited_at=1633046500000.0,
+            message_created_at=1633046400.0,  # Equivalent to 2021-10-01T00:00:00 UTC
+            message_edited_at=1633046500.0,
             mentions=["user2"],
             repliers=["user3"],
             reactors=["user4"],
@@ -41,7 +41,7 @@ class TestExtractMessagesDaily(unittest.TestCase):
         mock_extract.return_value = [msg]
 
         result = self.extractor.extract(from_date=None)
-        expected_date = datetime.fromtimestamp(msg.message_created_at / 1000).date()
+        expected_date = datetime.fromtimestamp(msg.message_created_at).date()
 
         self.assertIn(expected_date, result, "Expected date key in result")
         self.assertEqual(
@@ -59,8 +59,8 @@ class TestExtractMessagesDaily(unittest.TestCase):
             message_id=1,
             message_text="Message 1",
             author_username="user1",
-            message_created_at=1633046400000.0,  # Equivalent to 2021-10-01
-            message_edited_at=1633046500000.0,
+            message_created_at=1633046400.0,  # Equivalent to 2021-10-01
+            message_edited_at=1633046500.0,
             mentions=["user2"],
             repliers=["user3"],
             reactors=["user4"],
@@ -69,8 +69,8 @@ class TestExtractMessagesDaily(unittest.TestCase):
             message_id=2,
             message_text="Message 2",
             author_username="user2",
-            message_created_at=1633050000000.0,  # Same date as msg1
-            message_edited_at=1633050500000.0,
+            message_created_at=1633050000.0,  # Same date as msg1
+            message_edited_at=1633050500.0,
             mentions=["user1"],
             repliers=["user3"],
             reactors=["user4"],
@@ -78,7 +78,7 @@ class TestExtractMessagesDaily(unittest.TestCase):
         mock_extract.return_value = [msg1, msg2]
 
         result = self.extractor.extract(from_date=None)
-        expected_date = datetime.fromtimestamp(msg1.message_created_at / 1000).date()
+        expected_date = datetime.fromtimestamp(msg1.message_created_at).date()
 
         self.assertIn(expected_date, result, "Expected date key in result")
         self.assertEqual(
@@ -94,8 +94,8 @@ class TestExtractMessagesDaily(unittest.TestCase):
             message_id=1,
             message_text="Message 1",
             author_username="user1",
-            message_created_at=1633046400000.0,  # 2021-10-01
-            message_edited_at=1633046500000.0,
+            message_created_at=1633046400.0,  # 2021-10-01
+            message_edited_at=1633046500.0,
             mentions=["user2"],
             repliers=["user3"],
             reactors=["user4"],
@@ -104,8 +104,8 @@ class TestExtractMessagesDaily(unittest.TestCase):
             message_id=2,
             message_text="Message 2",
             author_username="user2",
-            message_created_at=1633132800000.0,  # 2021-10-02
-            message_edited_at=1633132900000.0,
+            message_created_at=1633132800.0,  # 2021-10-02
+            message_edited_at=1633132900.0,
             mentions=["user1"],
             repliers=["user3"],
             reactors=["user4"],
@@ -113,8 +113,8 @@ class TestExtractMessagesDaily(unittest.TestCase):
         mock_extract.return_value = [msg1, msg2]
 
         result = self.extractor.extract(from_date=None)
-        date1 = datetime.fromtimestamp(msg1.message_created_at / 1000).date()
-        date2 = datetime.fromtimestamp(msg2.message_created_at / 1000).date()
+        date1 = datetime.fromtimestamp(msg1.message_created_at).date()
+        date2 = datetime.fromtimestamp(msg2.message_created_at).date()
 
         self.assertIn(date1, result, "Expected first date key in result")
         self.assertIn(date2, result, "Expected second date key in result")

--- a/dags/hivemind_telegram_etl.py
+++ b/dags/hivemind_telegram_etl.py
@@ -127,19 +127,22 @@ def create_telegram_dag(dag_type: Literal["messages", "summaries"]) -> DAG:
                 from_date = latest_date - timedelta(days=30)
                 logging.info(f"Started extracting from date: {from_date}!")
                 messages = extractor.extract(from_date=from_date)
+                msg_count = len(messages)
             else:
                 if dag_type == "messages":
                     logging.info("Started extracting data from scratch!")
                     messages = extractor.extract()
+                    msg_count = len(messages)
                 else:
                     logging.info(f"Started extracting from date: {latest_date}!")
                     messages = extractor.extract(from_date=latest_date)
+                    msg_count = len(sum(messages.values(), []))
 
-            logging.info(f"Extracted {len(messages)} messages!")
+            logging.info(f"Extracted {msg_count} messages!")
 
             # Process and load data
             documents = process_data(messages)
-            logging.info(f"Transformed {len(messages)} messages!")
+            logging.info(f"Transformed {len(documents)} messages!")
 
             ingestion_pipeline.run_pipeline(docs=documents)
             logging.info("Finished loading into database!")

--- a/dags/hivemind_telegram_etl.py
+++ b/dags/hivemind_telegram_etl.py
@@ -127,16 +127,18 @@ def create_telegram_dag(dag_type: Literal["messages", "summaries"]) -> DAG:
                 from_date = latest_date - timedelta(days=30)
                 logging.info(f"Started extracting from date: {from_date}!")
                 messages = extractor.extract(from_date=from_date)
-                msg_count = len(messages)
             else:
                 if dag_type == "messages":
                     logging.info("Started extracting data from scratch!")
                     messages = extractor.extract()
-                    msg_count = len(messages)
                 else:
                     logging.info(f"Started extracting from date: {latest_date}!")
                     messages = extractor.extract(from_date=latest_date)
-                    msg_count = len(sum(messages.values(), []))
+
+            if dag_type == "messages":
+                msg_count = len(messages)
+            else:
+                msg_count = len(sum(messages.values(), []))
 
             logging.info(f"Extracted {msg_count} messages!")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `ExtractMessages`, `ExtractMessagesDaily`, and other related classes to accept `chat_id` as an integer, enhancing data type consistency.
	- Improved message date extraction logic for `ExtractMessagesDaily` to directly use timestamps in seconds.
	- Added logging enhancements to track the number of messages extracted during Telegram data processing.

- **Bug Fixes**
	- Adjusted timestamp handling in tests to align with the new second-based format, ensuring accurate date extraction.

- **Tests**
	- Updated unit tests to reflect changes in `chat_id` type and timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->