### PR TITLE
fix: ensure chat_id is an integer in message URL construction

### DIFF
--- a/dags/hivemind_etl_helpers/src/db/telegram/transform/messages.py
+++ b/dags/hivemind_etl_helpers/src/db/telegram/transform/messages.py
@@ -38,7 +38,7 @@ class TransformMessages:
                     "replies": message.repliers,
                     "reactors": message.reactors,
                     "chat_name": self.chat_name,
-                    "url": f"https://t.me/c/{chat_id}/{message.message_id}",
+                    "url": f"https://t.me/c/{int(chat_id)}/{message.message_id}",
                 },
                 excluded_embed_metadata_keys=[
                     "author",

--- a/dags/hivemind_etl_helpers/tests/unit/test_telegram_daily_summarize.py
+++ b/dags/hivemind_etl_helpers/tests/unit/test_telegram_daily_summarize.py
@@ -13,7 +13,7 @@ class TestTelegramSummarize(unittest.TestCase):
         Settings.chunk_size = 256
         Settings.embed_model = MockEmbedding(embed_dim=1024)
 
-        self.summarizer = SummarizeMessages(chat_id="temp_id", chat_name="temp_chat")
+        self.summarizer = SummarizeMessages(chat_id="1111111", chat_name="temp_chat")
 
     def test_summarize_empty_messages(self):
         summaries = self.summarizer.summarize_daily(messages={})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected URL generation for messages by properly converting chat ID to an integer.
	- Improved handling of chat ID in message metadata.
- **Tests**
	- Updated test setup to use a specific chat ID for better test accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->