### PR TITLE
fix: convert chat_id to float before constructing message URL

### DIFF
--- a/dags/hivemind_etl_helpers/src/db/telegram/transform/messages.py
+++ b/dags/hivemind_etl_helpers/src/db/telegram/transform/messages.py
@@ -38,7 +38,7 @@ class TransformMessages:
                     "replies": message.repliers,
                     "reactors": message.reactors,
                     "chat_name": self.chat_name,
-                    "url": f"https://t.me/c/{int(chat_id)}/{message.message_id}",
+                    "url": f"https://t.me/c/{int(float(chat_id))}/{message.message_id}",
                 },
                 excluded_embed_metadata_keys=[
                     "author",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of chat ID conversion to ensure accurate URL generation when processing messages with potential decimal point representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->