### PR TITLE
fix: update test assertion to use set for category IDs comparison

### DIFF
--- a/dags/analyzer_helper/tests/integration/test_discourse_fetch_categories.py
+++ b/dags/analyzer_helper/tests/integration/test_discourse_fetch_categories.py
@@ -82,4 +82,4 @@ class TestDiscourseFetchingCategories(TestCase):
         category_ids = self.fetcher.fetch_all()
 
         self.assertEqual(len(category_ids), 3)
-        self.assertEqual(category_ids, [1.0, 2.0, 3.0])
+        self.assertEqual(set(category_ids), set([1.0, 2.0, 3.0]))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test assertion for discourse category fetching to be order-independent
	- Improved test flexibility by using set comparison instead of strict list comparison

<!-- end of auto-generated comment: release notes by coderabbit.ai -->