### PR TITLE
fix: ensure platform_id is consistently treated as a string in the Te…

### DIFF
--- a/dags/hivemind_telegram_etl.py
+++ b/dags/hivemind_telegram_etl.py
@@ -73,7 +73,7 @@ def create_telegram_dag(dag_type: Literal["messages", "summaries"]) -> DAG:
             return {
                 "chat_info": chat_info,
                 "community_id": str(community_id),
-                "platform_id": platform_id,
+                "platform_id": str(platform_id),
             }
 
         @task(trigger_rule=TriggerRule.NONE_SKIPPED)


### PR DESCRIPTION
…legram ETL module!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that the platform ID in chat existence task results is always returned as a string, improving data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->