### PR TITLE
feat: set max active tasks limit for Discord ETL DAGs to improve concurrency!

### DIFF
--- a/dags/hivemind_discord_etl.py
+++ b/dags/hivemind_discord_etl.py
@@ -16,6 +16,7 @@ with DAG(
     schedule_interval="0 2 * * *",
     catchup=False,
     max_active_runs=1,
+    max_active_tasks=3,
 ) as dag:
 
     @task
@@ -59,6 +60,7 @@ with DAG(
     schedule_interval="0 2 * * *",
     catchup=False,
     max_active_runs=1,
+    max_active_tasks=3,
 ) as dag:
 
     @task


### PR DESCRIPTION
This is not to encounter issues on server.