### PR TITLE
feat: add 'from_start' parameter to Discord ETL processes for from scratch extraction!

### DIFF
--- a/dags/hivemind_discord_etl.py
+++ b/dags/hivemind_discord_etl.py
@@ -78,13 +78,21 @@ with DAG(
 ) as dag:
 
     @task
-    def get_mongo_discord_communities() -> list[dict[str, str | datetime | list]]:
+    def get_mongo_discord_communities(**kwargs) -> list[dict[str, str | datetime | list]]:
         """
         Getting all communities having discord from database
         this function is the same with `get_discord_communities`
         we just changed the name for the pylint
         """
+        from_start = kwargs["dag_run"].conf.get("from_start", False)
+        logging.info(f"From start: {from_start}")
+
         communities = ModulesDiscord().get_learning_platforms()
+
+        if from_start:
+            for community in communities:
+                community["from_start"] = from_start
+
         return communities
 
     @task

--- a/dags/hivemind_etl_helpers/discord_mongo_summary_etl.py
+++ b/dags/hivemind_etl_helpers/discord_mongo_summary_etl.py
@@ -18,6 +18,7 @@ def process_discord_summaries(
     platform_id: str,
     selected_channels: list[str],
     default_from_date: datetime,
+    from_start: bool = False,
     verbose: bool = False,
 ) -> None:
     """
@@ -36,6 +37,9 @@ def process_discord_summaries(
         a list of channels to start processing the data
     default_from_date : datetime
         the default from_date set in db
+    from_start : bool
+        whether to start from the beginning of the data or not
+        default is `False`
     verbose : bool
         verbose the process of summarization or not
         if `True` the summarization process will be printed out
@@ -48,7 +52,7 @@ def process_discord_summaries(
         Traceloop.init(app_name="hivemind-discord-summary", api_endpoint=otel_endpoint)
 
     guild_id = find_guild_id_by_platform_id(platform_id)
-    logging.info(f"COMMUNITYID: {community_id}, GUILDID: {guild_id}")
+    logging.info(f"COMMUNITYID: {community_id}, GUILDID: {guild_id} | from_start: {from_start}")
     
     collection_name = f"{platform_id}_summary"
     
@@ -64,7 +68,7 @@ def process_discord_summaries(
         field_schema=models.PayloadSchemaType.FLOAT,
     )
 
-    if latest_date is not None:
+    if latest_date is not None and not from_start:
         # Start from 1 day before so to catch all the last day data
         from_date = latest_date - timedelta(days=1)
         logging.info(f"Started extracting summaries from date: {from_date}!")

--- a/dags/hivemind_etl_helpers/discord_mongo_vector_store_etl.py
+++ b/dags/hivemind_etl_helpers/discord_mongo_vector_store_etl.py
@@ -16,6 +16,7 @@ def process_discord_guild_mongo(
     platform_id: str,
     selected_channels: list[str],
     default_from_date: datetime,
+    from_start: bool = False,
 ) -> None:
     """
     process the discord guild messages from mongodb
@@ -31,9 +32,14 @@ def process_discord_guild_mongo(
         a list of channels to start processing the data
     default_from_date : datetime
         the default from_date set in db
+    from_date : bool
+        whether to start from the beginning of the data or not
+        default is `False`
     """
     guild_id = find_guild_id_by_platform_id(platform_id)
-    logging.info(f"COMMUNITYID: {community_id}, GUILDID: {guild_id}")
+    logging.info(
+        f"COMMUNITYID: {community_id}, GUILDID: {guild_id} | from_start: {from_start}"
+    )
     
     collection_name = platform_id
     
@@ -51,7 +57,7 @@ def process_discord_guild_mongo(
     # because qdrant might have precision differences 
     # we might get duplicate messages
     # so adding just a second after
-    if latest_date is not None:
+    if latest_date is not None and not from_start:
         from_date = latest_date + timedelta(seconds=1)
         logging.info(f"Started extracting from date: {from_date}!")
     else:


### PR DESCRIPTION
Introduced a 'from_start' boolean parameter across various functions to control data processing behavior. Updated logging to include 'from_start' status for better traceability. Adjusted date handling logic to accommodate this new parameter, ensuring accurate data extraction based on user input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a run-time "start from scratch" option to trigger full reprocessing of Discord vector stores and summaries.

- **Improvements**
  - Propagated the start-from-scratch flag across related tasks to enable consistent gating.
  - Logs now show when a full start is used per community for better traceability.

- **Documentation**
  - Updated descriptions to document the start-from-scratch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->