### PR TITLE
feat: update discord summary dates to string instead of float!

### DIFF
--- a/dags/hivemind_etl_helpers/discord_mongo_summary_etl.py
+++ b/dags/hivemind_etl_helpers/discord_mongo_summary_etl.py
@@ -65,10 +65,13 @@ def process_discord_summaries(
     # We filter for daily summaries by checking the type field
     latest_date = ingestion_pipeline.get_latest_document_date(
         field_name="date",
-        field_schema=models.PayloadSchemaType.FLOAT,
+        field_schema=models.PayloadSchemaType.DATETIME,
     )
 
     if latest_date is not None and not from_start:
+        # Convert string date to datetime if needed
+        if isinstance(latest_date, str):
+            latest_date = datetime.strptime(latest_date, "%Y-%m-%d")
         # Start from 1 day before so to catch all the last day data
         from_date = latest_date - timedelta(days=1)
         logging.info(f"Started extracting summaries from date: {from_date}!")
@@ -95,7 +98,7 @@ def process_discord_summaries(
             f"Processing streamed batch {batch_index} | size={len(batch)}"
         )
         # Ensure final sort in case upstream changed batch boundaries
-        batch.sort(key=lambda d: d.metadata.get("date", 0.0))
+        batch.sort(key=lambda d: d.metadata.get("date", "0000-00-00"))
         ingestion_pipeline.run_pipeline(docs=batch)
         batch_index += 1
 

--- a/dags/hivemind_etl_helpers/src/db/discord/discord_summary.py
+++ b/dags/hivemind_etl_helpers/src/db/discord/discord_summary.py
@@ -271,7 +271,7 @@ class DiscordSummary(PrepareSummaries):
                 + channel_summary_documenets
                 + daily_summary_documents
             )
-            day_docs.sort(key=lambda d: datetime.fromtimestamp(d.metadata["date"]))
+            day_docs.sort(key=lambda d: d.metadata["date"])
 
             buffer.extend(day_docs)
 
@@ -279,7 +279,7 @@ class DiscordSummary(PrepareSummaries):
             while len(buffer) >= batch_size:
                 batch = buffer[:batch_size]
                 batch.sort(
-                    key=lambda d: datetime.fromtimestamp(d.metadata["date"])  # type: ignore
+                    key=lambda d: d.metadata["date"]  # type: ignore
                 )
                 yield batch
                 buffer = buffer[batch_size:]
@@ -287,6 +287,6 @@ class DiscordSummary(PrepareSummaries):
         # Yield any remaining documents
         if buffer:
             buffer.sort(
-                key=lambda d: datetime.fromtimestamp(d.metadata["date"])  # type: ignore
+                key=lambda d: d.metadata["date"]  # type: ignore
             )
             yield buffer

--- a/dags/hivemind_etl_helpers/src/db/discord/summary/prepare_grouped_data.py
+++ b/dags/hivemind_etl_helpers/src/db/discord/summary/prepare_grouped_data.py
@@ -11,7 +11,7 @@ def prepare_grouped_data(
     guild_id: str,
     from_date: datetime,
     selected_channels: list[str],
-) -> dict[float, dict[str, dict[str | None, list]]]:
+) -> dict[float | str, dict[str, dict[str | None, list]]]:
     """
     prepare the nested dictionary of grouped data
 
@@ -27,7 +27,7 @@ def prepare_grouped_data(
 
     Returns
     --------
-    raw_data_grouped : dict[float, dict[str, dict[str | None, list]]]
+    raw_data_grouped : dict[float | str, dict[str, dict[str | None, list]]]
         grouping the messages into a nested dictionary
         first level should be representative of day, second level channel
         and third level would be the thread
@@ -50,7 +50,7 @@ def prepare_grouped_data(
 def group_per_channel_thread(
     guild_id: str,
     daily_messages: dict[float, list]
-) -> dict[float, dict[str, dict[str | None, list]]]:
+) -> dict[float | str, dict[str, dict[str | None, list]]]:
     """
     group the data into a nested dictionary.
     Note that the daily_messages should be already grouped by day
@@ -65,13 +65,13 @@ def group_per_channel_thread(
 
     Returns
     ---------
-    raw_data_grouped : dict[float, dict[str, dict[str | None, list]]]
+    raw_data_grouped : dict[float | str, dict[str, dict[str | None, list]]]
         grouping the messages into a nested dictionary
         first level should be representative of day, second level channel
         and third level would be the thread
         (thread can be `None` meaning it is the main channel)
     """
-    raw_data_grouped: dict[float, dict[str, dict[str | None, list]]] = {}
+    raw_data_grouped: dict[float | str, dict[str, dict[str | None, list]]] = {}
 
     name_fetcher = FetchDiscordChannelThreadNames(guild_id)
 

--- a/dags/hivemind_etl_helpers/src/db/discord/summary/prepare_summaries.py
+++ b/dags/hivemind_etl_helpers/src/db/discord/summary/prepare_summaries.py
@@ -35,9 +35,9 @@ class PrepareSummaries(SummaryBase):
     def prepare_thread_summaries(
         self,
         guild_id: str,
-        raw_data_grouped: dict[float, dict[str, dict[str | None, list]]],
+        raw_data_grouped: dict[float | str, dict[str, dict[str | None, list]]],
         summarization_query: str,
-    ) -> dict[float, dict[str, dict[str | None, str]]]:
+    ) -> dict[float | str, dict[str, dict[str | None, str]]]:
         """
         prepare the summaries for threads
 
@@ -45,14 +45,14 @@ class PrepareSummaries(SummaryBase):
         -----------
         guild_id : str
             the guild id to convert the raw messages to documents
-        raw_data_grouped : dict[float, dict[str, dict[str | None, list]]]
+        raw_data_grouped : dict[float | str, dict[str, dict[str | None, list]]]
             the raw data grouped by date, channel and thread in third nesting level
         summarization_query : str
             the summarization query to do on the LLM
 
         Returns
         --------
-        thread_summaries : dict[float, dict[str, dict[str | None, str]]]
+        thread_summaries : dict[float | str, dict[str, dict[str | None, str]]]
             the summaries per date, channel, and thread
             the third level are the summaries saved
         """
@@ -65,7 +65,7 @@ class PrepareSummaries(SummaryBase):
                 total_call_count += len(raw_data_grouped[date][channel])
 
         idx = 1
-        thread_summaries: dict[str, dict[str, dict[str | None, str]]] = {}
+        thread_summaries: dict[float | str, dict[str, dict[str | None, str]]] = {}
         for date in raw_data_grouped.keys():
             for channel in raw_data_grouped[date].keys():
                 for thread in raw_data_grouped[date][channel].keys():
@@ -89,22 +89,22 @@ class PrepareSummaries(SummaryBase):
 
     def prepare_channel_summaries(
         self,
-        thread_summaries: dict[float, dict[str, dict[str | None, str]]],
+        thread_summaries: dict[float | str, dict[str, dict[str | None, str]]],
         summarization_query: str,
-    ) -> tuple[dict[float, dict[str, str]], list[Document]]:
+    ) -> tuple[dict[float | str, dict[str, str]], list[Document]]:
         """
         prepare the daily channel summaries based on the thread summaries
 
         Parameters
         -----------
-        thread_summaries : dict[float, dict[str, dict[str | None, str]]]
+        thread_summaries : dict[float | str, dict[str, dict[str | None, str]]]
             the thread summaries per day and per channel
         summarization_query : str
             the summarization query to do on the LLM
 
         Returns
         ---------
-        channel_summaries : dict[float, dict[str, str]]
+        channel_summaries : dict[float | str, dict[str, str]]
             the summaries per day for different channel
         thread_summary_documenets : list[llama_index.Document]
             a list of documents related to channel summaries
@@ -116,7 +116,7 @@ class PrepareSummaries(SummaryBase):
             total_call_count += len(thread_summaries[date].keys())
 
         thread_summary_documenets: list[Document] = []
-        channel_summaries: dict[str, dict[str, str]] = {}
+        channel_summaries: dict[float | str, dict[str, str]] = {}
 
         idx = 1
         for date in thread_summaries.keys():
@@ -167,29 +167,29 @@ class PrepareSummaries(SummaryBase):
 
     def prepare_daily_summaries(
         self,
-        channel_summaries: dict[float, dict[str, str]],
+        channel_summaries: dict[float | str, dict[str, str]],
         summarization_query: str,
-    ) -> tuple[dict[str, str], list[Document]]:
+    ) -> tuple[dict[float | str, str], list[Document]]:
         """
         prepare the daily summaries based on the channel summaries
 
         Parameters
         -----------
-        channel_summaries : dict[float, dict[str, str]]
+        channel_summaries : dict[float | str, dict[str, str]]
             the thread summaries per day, per channel
         summarization_query : str
             the summarization query to do on the LLM
 
         Returns
         ---------
-        daily_summaries : dict[float, str]
+        daily_summaries : dict[float | str, str]
             the summaries per day for different channel
         channel_summary_documenets : list[llama_index.Document]
             a list of documents related to the summaries of the channel
         """
         logging.info(f"{self.prefix}Preparing the daily summaries")
         channel_summary_documenets: list[Document] = []
-        daily_summaries: dict[float, str] = {}
+        daily_summaries: dict[float | str, str] = {}
 
         total_call_count = len(channel_summaries.keys())
 

--- a/dags/hivemind_etl_helpers/src/utils/sort_summary_docs.py
+++ b/dags/hivemind_etl_helpers/src/utils/sort_summary_docs.py
@@ -30,7 +30,12 @@ def sort_summaries_daily(
 
     # Define a custom sorting key function based on the date in metadata
     def get_date(doc: Document):
-        return datetime.fromtimestamp(doc.metadata["date"])
+        date_value = doc.metadata["date"]
+        # Handle both timestamp (float) and string date formats
+        if isinstance(date_value, str):
+            return datetime.strptime(date_value, "%Y-%m-%d")
+        else:
+            return datetime.fromtimestamp(date_value)
 
     # Sort the documents based on the custom key
     docs_sorted = sorted(all_docs, key=get_date)


### PR DESCRIPTION
+ reason: Qdrant didn't support eact match float query (prob. our version didn't support it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed date parsing to support both timestamps and YYYY-MM-DD strings, preventing mixed-type sort errors.
  - Ensured consistent date formatting in metadata (YYYY-MM-DD) across all summaries.
  - Improved latest data detection for more reliable incremental runs.

- Refactor
  - Unified sorting to handle mixed date types seamlessly across thread, channel, and daily summaries.
  - Included channel and daily summaries in per-day processing for more complete results.
  - Improved batching and buffering order for more predictable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->