### PR TITLE
fix: include doc_id in Document creation for better metadata handling!

### DIFF
--- a/dags/hivemind_etl_helpers/src/db/discord/utils/transform_discord_raw_messges.py
+++ b/dags/hivemind_etl_helpers/src/db/discord/utils/transform_discord_raw_messges.py
@@ -233,7 +233,11 @@ def prepare_document(
 
     doc: Document
     if not exclude_metadata:
-        doc = Document(text=content, metadata=msg_meta_data)
+        doc = Document(
+            text=content,
+            metadata=msg_meta_data,
+            doc_id=message_id,
+        )
         doc.excluded_embed_metadata_keys = [
             "channel",
             "date",
@@ -272,6 +276,9 @@ def prepare_document(
             "url",
         ]
     else:
-        doc = Document(text=content)
+        doc = Document(
+            text=content,
+            doc_id=message_id,
+        )
 
     return doc


### PR DESCRIPTION
This update ensures that the doc_id is included when creating Document instances, both with and without metadata. This change enhances the consistency and traceability of documents processed in the ETL pipeline.