### PR TITLE
feat: add reset parameter to data cleaning functions and fix python metadata reading!

### DIFF
--- a/dags/data_cleaning_pipeline.py
+++ b/dags/data_cleaning_pipeline.py
@@ -91,7 +91,7 @@ with DAG(
 
         # 1) Scroll points lazily and group/merge by doc_id without materializing all points
         merged_by_doc: dict[str, dict[str, Any]] = group_and_merge_by_doc_id(
-            scroll_all_points(client, collection=collection, batch_size=batch_size)
+            scroll_all_points(client, collection=collection, batch_size=batch_size), reset=reset_progress
         )
         doc_ids: list[str]
         if sort_doc_ids:


### PR DESCRIPTION
Introduce a reset parameter to the extract_text_and_order and group_and_merge_by_doc_id functions, allowing for more control over data processing. This enhancement enables the option to skip cleaned data or start from the beginning, improving flexibility in the data cleaning pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a reset option to the data cleaning pipeline to optionally reprocess content regardless of prior cleaning status, enabling full re-ingestion when needed.
- Improvements
  - More robust parsing of embedded content with safer fallbacks for malformed data.
  - Clearer error messages during parsing failures for easier troubleshooting.
  - Consistent identifier handling during grouping and merging.
  - Respect for existing cleaning status when not resetting, reducing unnecessary processing and preserving validated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->