### PR TITLE
feat: enhance Discord ETL with community and platform filtering, and …

### DIFF
--- a/dags/hivemind_etl_helpers/discord_cleanup_collection.py
+++ b/dags/hivemind_etl_helpers/discord_cleanup_collection.py
@@ -1,0 +1,138 @@
+import logging
+from tc_hivemind_backend.ingest_qdrant import CustomIngestionPipeline
+from tc_hivemind_backend.db.mongo import MongoSingleton
+
+
+def cleanup_discord_summary_collections(community_id: str, platform_id: str) -> None:
+    """
+    Delete Qdrant collection and MongoDB collections for discord summaries.
+    
+    Parameters
+    -----------
+    community_id : str
+        the community id to delete collections for
+    platform_id : str
+        discord platform id to delete collections for
+    """
+    logging.info(f"Starting cleanup for community_id: {community_id}, platform_id: {platform_id}")
+    
+    # Delete Qdrant collection
+    qdrant_collection_name = f"{community_id}_{platform_id}_summary"
+    logging.info(f"Deleting Qdrant collection: {qdrant_collection_name}")
+    
+    try:
+        # Create a CustomIngestionPipeline instance to access the Qdrant client
+        temp_pipeline = CustomIngestionPipeline(
+            community_id=community_id, 
+            collection_name=f"{platform_id}_summary",
+            use_cache=False,
+        )
+        # Access the Qdrant client and delete the collection
+        temp_pipeline.qdrant_client.delete_collection(collection_name=qdrant_collection_name)
+        logging.info(f"Successfully deleted Qdrant collection: {qdrant_collection_name}")
+    except Exception as e:
+        logging.warning(f"Failed to delete Qdrant collection {qdrant_collection_name}: {e}")
+    
+    # Delete MongoDB collections
+    mongo_db_name = f"docstore_{community_id}"
+    logging.info(f"Deleting MongoDB collections in database: {mongo_db_name}")
+    
+    try:
+        mongo_client = MongoSingleton.get_instance().client
+        db = mongo_client[mongo_db_name]
+        
+        # Delete metadata collection
+        metadata_collection_name = f"{platform_id}/metadata"
+        if metadata_collection_name in db.list_collection_names():
+            db.drop_collection(metadata_collection_name)
+            logging.info(f"Successfully deleted MongoDB collection: {metadata_collection_name}")
+        else:
+            logging.info(f"MongoDB collection {metadata_collection_name} does not exist")
+        
+        # Delete data collection  
+        data_collection_name = f"{platform_id}/data"
+        if data_collection_name in db.list_collection_names():
+            db.drop_collection(data_collection_name)
+            logging.info(f"Successfully deleted MongoDB collection: {data_collection_name}")
+        else:
+            logging.info(f"MongoDB collection {data_collection_name} does not exist")
+            
+    except Exception as e:
+        logging.warning(f"Failed to delete MongoDB collections in {mongo_db_name}: {e}")
+    
+    logging.info(f"Cleanup completed for community_id: {community_id}, platform_id: {platform_id}")
+
+
+def cleanup_discord_vector_collections(community_id: str, platform_id: str) -> None:
+    """
+    Delete Qdrant collection and MongoDB collections for discord base vector store.
+
+    Parameters
+    -----------
+    community_id : str
+        the community id to delete collections for
+    platform_id : str
+        discord platform id to delete collections for
+    """
+    logging.info(
+        f"Starting vector cleanup for community_id: {community_id}, platform_id: {platform_id}"
+    )
+
+    # Delete Qdrant collection (base vectors use collection name without suffix)
+    qdrant_collection_name = f"{community_id}_{platform_id}"
+    logging.info(f"Deleting Qdrant collection: {qdrant_collection_name}")
+
+    try:
+        temp_pipeline = CustomIngestionPipeline(
+            community_id=community_id,
+            collection_name=platform_id,
+            use_cache=False,
+        )
+        temp_pipeline.qdrant_client.delete_collection(
+            collection_name=qdrant_collection_name
+        )
+        logging.info(
+            f"Successfully deleted Qdrant collection: {qdrant_collection_name}"
+        )
+    except Exception as e:
+        logging.warning(
+            f"Failed to delete Qdrant collection {qdrant_collection_name}: {e}"
+        )
+
+    # Delete MongoDB collections (shared naming without suffix)
+    mongo_db_name = f"docstore_{community_id}"
+    logging.info(f"Deleting MongoDB collections in database: {mongo_db_name}")
+
+    try:
+        mongo_client = MongoSingleton.get_instance().client
+        db = mongo_client[mongo_db_name]
+
+        metadata_collection_name = f"{platform_id}/metadata"
+        if metadata_collection_name in db.list_collection_names():
+            db.drop_collection(metadata_collection_name)
+            logging.info(
+                f"Successfully deleted MongoDB collection: {metadata_collection_name}"
+            )
+        else:
+            logging.info(
+                f"MongoDB collection {metadata_collection_name} does not exist"
+            )
+
+        data_collection_name = f"{platform_id}/data"
+        if data_collection_name in db.list_collection_names():
+            db.drop_collection(data_collection_name)
+            logging.info(
+                f"Successfully deleted MongoDB collection: {data_collection_name}"
+            )
+        else:
+            logging.info(
+                f"MongoDB collection {data_collection_name} does not exist"
+            )
+    except Exception as e:
+        logging.warning(
+            f"Failed to delete MongoDB collections in {mongo_db_name}: {e}"
+        )
+
+    logging.info(
+        f"Vector cleanup completed for community_id: {community_id}, platform_id: {platform_id}"
+    )

--- a/dags/hivemind_etl_helpers/discord_cleanup_collection.py
+++ b/dags/hivemind_etl_helpers/discord_cleanup_collection.py
@@ -23,7 +23,7 @@ def cleanup_discord_summary_collections(community_id: str, platform_id: str) -> 
     try:
         # Create a CustomIngestionPipeline instance to access the Qdrant client
         temp_pipeline = CustomIngestionPipeline(
-            community_id=community_id, 
+            community_id=community_id,
             collection_name=f"{platform_id}_summary",
             use_cache=False,
         )
@@ -42,15 +42,15 @@ def cleanup_discord_summary_collections(community_id: str, platform_id: str) -> 
         db = mongo_client[mongo_db_name]
         
         # Delete metadata collection
-        metadata_collection_name = f"{platform_id}/metadata"
+        metadata_collection_name = f"{platform_id}_summary/metadata"
         if metadata_collection_name in db.list_collection_names():
             db.drop_collection(metadata_collection_name)
             logging.info(f"Successfully deleted MongoDB collection: {metadata_collection_name}")
         else:
             logging.info(f"MongoDB collection {metadata_collection_name} does not exist")
         
-        # Delete data collection  
-        data_collection_name = f"{platform_id}/data"
+        # Delete data collection
+        data_collection_name = f"{platform_id}_summary/data"
         if data_collection_name in db.list_collection_names():
             db.drop_collection(data_collection_name)
             logging.info(f"Successfully deleted MongoDB collection: {data_collection_name}")

--- a/dags/hivemind_etl_helpers/discord_mongo_summary_etl.py
+++ b/dags/hivemind_etl_helpers/discord_mongo_summary_etl.py
@@ -7,71 +7,11 @@ from hivemind_etl_helpers.src.db.discord.discord_summary import DiscordSummary
 from hivemind_etl_helpers.src.db.discord.find_guild_id import (
     find_guild_id_by_platform_id,
 )
+from hivemind_etl_helpers.discord_cleanup_collection import cleanup_discord_summary_collections
 from llama_index.core.response_synthesizers import get_response_synthesizer
 from qdrant_client.http import models
-from tc_hivemind_backend.db.mongo import MongoSingleton
 from tc_hivemind_backend.ingest_qdrant import CustomIngestionPipeline
 from traceloop.sdk import Traceloop
-
-
-def cleanup_discord_summary_collections(community_id: str, platform_id: str) -> None:
-    """
-    Delete Qdrant collection and MongoDB collections for discord summaries.
-    
-    Parameters
-    -----------
-    community_id : str
-        the community id to delete collections for
-    platform_id : str
-        discord platform id to delete collections for
-    """
-    logging.info(f"Starting cleanup for community_id: {community_id}, platform_id: {platform_id}")
-    
-    # Delete Qdrant collection
-    qdrant_collection_name = f"{community_id}_{platform_id}_summary"
-    logging.info(f"Deleting Qdrant collection: {qdrant_collection_name}")
-    
-    try:
-        # Create a CustomIngestionPipeline instance to access the Qdrant client
-        temp_pipeline = CustomIngestionPipeline(
-            community_id=community_id, 
-            collection_name=f"{platform_id}_summary",
-            use_cache=False,
-        )
-        # Access the Qdrant client and delete the collection
-        temp_pipeline.qdrant_client.delete_collection(collection_name=qdrant_collection_name)
-        logging.info(f"Successfully deleted Qdrant collection: {qdrant_collection_name}")
-    except Exception as e:
-        logging.warning(f"Failed to delete Qdrant collection {qdrant_collection_name}: {e}")
-    
-    # Delete MongoDB collections
-    mongo_db_name = f"docstore_{community_id}"
-    logging.info(f"Deleting MongoDB collections in database: {mongo_db_name}")
-    
-    try:
-        mongo_client = MongoSingleton.get_instance().client
-        db = mongo_client[mongo_db_name]
-        
-        # Delete metadata collection
-        metadata_collection_name = f"{platform_id}/metadata"
-        if metadata_collection_name in db.list_collection_names():
-            db.drop_collection(metadata_collection_name)
-            logging.info(f"Successfully deleted MongoDB collection: {metadata_collection_name}")
-        else:
-            logging.info(f"MongoDB collection {metadata_collection_name} does not exist")
-        
-        # Delete data collection  
-        data_collection_name = f"{platform_id}/data"
-        if data_collection_name in db.list_collection_names():
-            db.drop_collection(data_collection_name)
-            logging.info(f"Successfully deleted MongoDB collection: {data_collection_name}")
-        else:
-            logging.info(f"MongoDB collection {data_collection_name} does not exist")
-            
-    except Exception as e:
-        logging.warning(f"Failed to delete MongoDB collections in {mongo_db_name}: {e}")
-    
-    logging.info(f"Cleanup completed for community_id: {community_id}, platform_id: {platform_id}")
 
 
 def process_discord_summaries(

--- a/dags/hivemind_etl_helpers/discord_mongo_vector_store_etl.py
+++ b/dags/hivemind_etl_helpers/discord_mongo_vector_store_etl.py
@@ -7,6 +7,9 @@ from hivemind_etl_helpers.src.db.discord.discord_raw_message_to_document import 
 from hivemind_etl_helpers.src.db.discord.find_guild_id import (
     find_guild_id_by_platform_id,
 )
+from hivemind_etl_helpers.discord_cleanup_collection import (
+    cleanup_discord_vector_collections,
+)
 from qdrant_client.http import models
 from tc_hivemind_backend.ingest_qdrant import CustomIngestionPipeline
 
@@ -17,6 +20,7 @@ def process_discord_guild_mongo(
     selected_channels: list[str],
     default_from_date: datetime,
     from_start: bool = False,
+    cleanup_collections: bool = False,
 ) -> None:
     """
     process the discord guild messages from mongodb
@@ -40,13 +44,15 @@ def process_discord_guild_mongo(
     logging.info(
         f"COMMUNITYID: {community_id}, GUILDID: {guild_id} | from_start: {from_start}"
     )
-    
-    collection_name = platform_id
-    
+
+    # Cleanup collections if requested
+    if cleanup_collections:
+        cleanup_discord_vector_collections(community_id, platform_id)
+
     # Set up ingestion pipeline
     ingestion_pipeline = CustomIngestionPipeline(
         community_id=community_id,
-        collection_name=collection_name,
+        collection_name=platform_id,
         use_cache=False,
     )
 


### PR DESCRIPTION
…add cleanup functionality

- Updated `hivemind_discord_etl.py` to support optional filtering of communities by `community_id` and `platform_id` from `dag_run.conf`.
- Introduced `cleanup_collections` parameter to manage cleanup operations for Discord summaries and vector collections.
- Created `discord_cleanup_collection.py` to handle the deletion of Qdrant and MongoDB collections for both summaries and vector stores.
- Refactored `discord_mongo_summary_etl.py` and `discord_mongo_vector_store_etl.py` to utilize the new cleanup functions, improving code organization and reusability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Filter Discord ETL runs by community ID and/or platform ID.
  - Optional pre-run cleanup to remove existing summary and vector data for a selected community/platform.

- Improvements
  - Consistent propagation of the cleanup option across all Discord ETL paths.
  - Clearer logs showing applied filters, cleanup actions, and processing decisions.

- Refactor
  - Centralized cleanup utilities and updated ETL steps to consume them, reducing duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->